### PR TITLE
New dometools features and updates

### DIFF
--- a/Presets/GLSL_shaders/fulldome/Video_Mixer_dome.fs
+++ b/Presets/GLSL_shaders/fulldome/Video_Mixer_dome.fs
@@ -1,0 +1,471 @@
+/*{
+    "CATEGORIES": [
+        "General",
+        "DOME"
+    ],
+    "CREDIT": "Original code by Jamie Owen and Jean-Michaël Celerier. optimizations and dome version Edu Meneses + AI Assistant (Gemini)",
+    "DESCRIPTION": "8-channel video mixer with Aspect Ratio control",
+    "INPUTS": [
+        { "NAME": "t1", "LABEL" : "Texture 1", "TYPE": "image" },
+        { "NAME": "t2", "LABEL" : "Texture 2", "TYPE": "image" },
+        { "NAME": "t3", "LABEL" : "Texture 3", "TYPE": "image" },
+        { "NAME": "t4", "LABEL" : "Texture 4", "TYPE": "image" },
+        { "NAME": "t5", "LABEL" : "Texture 5", "TYPE": "image" },
+        { "NAME": "t6", "LABEL" : "Texture 6", "TYPE": "image" },
+        { "NAME": "t7", "LABEL" : "Texture 7", "TYPE": "image" },
+        { "NAME": "t8", "LABEL" : "Texture 8", "TYPE": "image" },
+        { "NAME": "keep_1_1_aspect", "LABEL": "Keep 1:1 Input Aspect", "TYPE": "bool", "DEFAULT": true },
+        { "NAME": "alpha1", "LABEL" : "Alpha 1", "DEFAULT": 1, "MAX": 1, "MIN": 0, "TYPE": "float" },
+        { "NAME": "alpha2", "LABEL" : "Alpha 2", "DEFAULT": 0, "MAX": 1, "MIN": 0, "TYPE": "float" },
+        { "NAME": "alpha3", "LABEL" : "Alpha 3", "DEFAULT": 0, "MAX": 1, "MIN": 0, "TYPE": "float" },
+        { "NAME": "alpha4", "LABEL" : "Alpha 4", "DEFAULT": 0, "MAX": 1, "MIN": 0, "TYPE": "float" },
+        { "NAME": "alpha5", "LABEL" : "Alpha 5", "DEFAULT": 0, "MAX": 1, "MIN": 0, "TYPE": "float" },
+        { "NAME": "alpha6", "LABEL" : "Alpha 6", "DEFAULT": 0, "MAX": 1, "MIN": 0, "TYPE": "float" },
+        { "NAME": "alpha7", "LABEL" : "Alpha 7", "DEFAULT": 0, "MAX": 1, "MIN": 0, "TYPE": "float" },
+        { "NAME": "alpha8", "LABEL" : "Alpha 8", "DEFAULT": 0, "MAX": 1, "MIN": 0, "TYPE": "float" },
+        { "VALUES" : [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 ],
+           "LABELS" : [ "Add", "Average", "Color Burn", "Color Dodge", "Darken", "Difference", 
+                        "Exclusion", "Glow", "Hard Light", "Hard Mix", "Lighten", "Linear Burn", 
+                        "Linear Dodge", "Linear Light", "Multiply", "Negation", "Normal", "Overlay", 
+                        "Phoenix", "Pin Light", "Reflect", "Screen", "Soft Light", "Subtract", "Vivid Light"],
+           "IDENTITY" : 1,
+           "DEFAULT" : 17,
+           "LABEL" : "Mode 1",
+           "TYPE" : "long",
+           "NAME" : "mode1"
+        },
+        { "VALUES" : [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 ],
+           "LABELS" : [ "Add", "Average", "Color Burn", "Color Dodge", "Darken", "Difference", 
+                        "Exclusion", "Glow", "Hard Light", "Hard Mix", "Lighten", "Linear Burn", 
+                        "Linear Dodge", "Linear Light", "Multiply", "Negation", "Normal", "Overlay", 
+                        "Phoenix", "Pin Light", "Reflect", "Screen", "Soft Light", "Subtract", "Vivid Light"],
+           "IDENTITY" : 1,
+           "DEFAULT" : 17,
+           "LABEL" : "Mode 2",
+           "TYPE" : "long",
+           "NAME" : "mode2"
+        },
+        { "VALUES" : [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 ],
+           "LABELS" : [ "Add", "Average", "Color Burn", "Color Dodge", "Darken", "Difference", 
+                        "Exclusion", "Glow", "Hard Light", "Hard Mix", "Lighten", "Linear Burn", 
+                        "Linear Dodge", "Linear Light", "Multiply", "Negation", "Normal", "Overlay", 
+                        "Phoenix", "Pin Light", "Reflect", "Screen", "Soft Light", "Subtract", "Vivid Light"],
+           "IDENTITY" : 1,
+           "DEFAULT" : 17,
+           "LABEL" : "Mode 3",
+           "TYPE" : "long",
+           "NAME" : "mode3"
+        },
+        { "VALUES" : [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 ],
+           "LABELS" : [ "Add", "Average", "Color Burn", "Color Dodge", "Darken", "Difference", 
+                        "Exclusion", "Glow", "Hard Light", "Hard Mix", "Lighten", "Linear Burn", 
+                        "Linear Dodge", "Linear Light", "Multiply", "Negation", "Normal", "Overlay", 
+                        "Phoenix", "Pin Light", "Reflect", "Screen", "Soft Light", "Subtract", "Vivid Light"],
+           "IDENTITY" : 1,
+           "DEFAULT" : 17,
+           "LABEL" : "Mode 4",
+           "TYPE" : "long",
+           "NAME" : "mode4"
+        },
+        { "VALUES" : [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 ],
+           "LABELS" : [ "Add", "Average", "Color Burn", "Color Dodge", "Darken", "Difference", 
+                        "Exclusion", "Glow", "Hard Light", "Hard Mix", "Lighten", "Linear Burn", 
+                        "Linear Dodge", "Linear Light", "Multiply", "Negation", "Normal", "Overlay", 
+                        "Phoenix", "Pin Light", "Reflect", "Screen", "Soft Light", "Subtract", "Vivid Light"],
+           "IDENTITY" : 1,
+           "DEFAULT" : 17,
+           "LABEL" : "Mode 5",
+           "TYPE" : "long",
+           "NAME" : "mode5"
+        },
+        { "VALUES" : [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 ],
+           "LABELS" : [ "Add", "Average", "Color Burn", "Color Dodge", "Darken", "Difference", 
+                        "Exclusion", "Glow", "Hard Light", "Hard Mix", "Lighten", "Linear Burn", 
+                        "Linear Dodge", "Linear Light", "Multiply", "Negation", "Normal", "Overlay", 
+                        "Phoenix", "Pin Light", "Reflect", "Screen", "Soft Light", "Subtract", "Vivid Light"],
+           "IDENTITY" : 1,
+           "DEFAULT" : 17,
+           "LABEL" : "Mode 6",
+           "TYPE" : "long",
+           "NAME" : "mode6"
+        },
+        { "VALUES" : [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 ],
+           "LABELS" : [ "Add", "Average", "Color Burn", "Color Dodge", "Darken", "Difference", 
+                        "Exclusion", "Glow", "Hard Light", "Hard Mix", "Lighten", "Linear Burn", 
+                        "Linear Dodge", "Linear Light", "Multiply", "Negation", "Normal", "Overlay", 
+                        "Phoenix", "Pin Light", "Reflect", "Screen", "Soft Light", "Subtract", "Vivid Light"],
+           "IDENTITY" : 1,
+           "DEFAULT" : 17,
+           "LABEL" : "Mode 7",
+           "TYPE" : "long",
+           "NAME" : "mode7"
+        }
+    ],
+    "ISFVSN": "2"
+}
+*/
+
+// --- Blend mode implementations ---
+vec3 blendPhoenix(vec3 base, vec3 blend) {
+  return min(base, blend) - max(base, blend) + vec3(1.0);
+}
+vec3 blendPhoenix(vec3 base, vec3 blend, float opacity) {
+  return (blendPhoenix(base, blend) * opacity + base * (1.0 - opacity));
+}
+float blendOverlay(float base, float blend) {
+  return base < 0.5 ? (2.0 * base * blend)
+                    : (1.0 - 2.0 * (1.0 - base) * (1.0 - blend));
+}
+vec3 blendOverlay(vec3 base, vec3 blend) {
+  return vec3(blendOverlay(base.r, blend.r), blendOverlay(base.g, blend.g),
+              blendOverlay(base.b, blend.b));
+}
+vec3 blendOverlay(vec3 base, vec3 blend, float opacity) {
+  return (blendOverlay(base, blend) * opacity + base * (1.0 - opacity));
+}
+vec3 blendNormal(vec3 base, vec3 blend) { return blend; }
+vec3 blendNormal(vec3 base, vec3 blend, float opacity) {
+  return (blendNormal(base, blend) * opacity + base * (1.0 - opacity));
+}
+vec3 blendNegation(vec3 base, vec3 blend) {
+  return vec3(1.0) - abs(vec3(1.0) - base - blend);
+}
+vec3 blendNegation(vec3 base, vec3 blend, float opacity) {
+  return (blendNegation(base, blend) * opacity + base * (1.0 - opacity));
+}
+vec3 blendMultiply(vec3 base, vec3 blend) { return base * blend; }
+vec3 blendMultiply(vec3 base, vec3 blend, float opacity) {
+  return (blendMultiply(base, blend) * opacity + base * (1.0 - opacity));
+}
+float blendReflect(float base, float blend) {
+  return (blend == 1.0) ? blend : min(base * base / (1.0 - blend), 1.0);
+}
+vec3 blendReflect(vec3 base, vec3 blend) {
+  return vec3(blendReflect(base.r, blend.r), blendReflect(base.g, blend.g),
+              blendReflect(base.b, blend.b));
+}
+vec3 blendReflect(vec3 base, vec3 blend, float opacity) {
+  return (blendReflect(base, blend) * opacity + base * (1.0 - opacity));
+}
+vec3 blendAverage(vec3 base, vec3 blend) { return (base + blend) / 2.0; }
+vec3 blendAverage(vec3 base, vec3 blend, float opacity) {
+  return (blendAverage(base, blend) * opacity + base * (1.0 - opacity));
+}
+float blendLinearBurn(float base, float blend) {
+  return max(base + blend - 1.0, 0.0);
+}
+vec3 blendLinearBurn(vec3 base, vec3 blend) {
+  return max(base + blend - vec3(1.0), vec3(0.0));
+}
+vec3 blendLinearBurn(vec3 base, vec3 blend, float opacity) {
+  return (blendLinearBurn(base, blend) * opacity + base * (1.0 - opacity));
+}
+float blendLighten(float base, float blend) { return max(blend, base); }
+vec3 blendLighten(vec3 base, vec3 blend) {
+  return vec3(blendLighten(base.r, blend.r), blendLighten(base.g, blend.g),
+              blendLighten(base.b, blend.b));
+}
+vec3 blendLighten(vec3 base, vec3 blend, float opacity) {
+  return (blendLighten(base, blend) * opacity + base * (1.0 - opacity));
+}
+float blendScreen(float base, float blend) {
+  return 1.0 - ((1.0 - base) * (1.0 - blend));
+}
+vec3 blendScreen(vec3 base, vec3 blend) {
+  return vec3(blendScreen(base.r, blend.r), blendScreen(base.g, blend.g),
+              blendScreen(base.b, blend.b));
+}
+vec3 blendScreen(vec3 base, vec3 blend, float opacity) {
+  return (blendScreen(base, blend) * opacity + base * (1.0 - opacity));
+}
+float blendSoftLight(float base, float blend) {
+  return (blend < 0.5)
+             ? (2.0 * base * blend + base * base * (1.0 - 2.0 * blend))
+             : (sqrt(base) * (2.0 * blend - 1.0) + 2.0 * base * (1.0 - blend));
+}
+vec3 blendSoftLight(vec3 base, vec3 blend) {
+  return vec3(blendSoftLight(base.r, blend.r), blendSoftLight(base.g, blend.g),
+              blendSoftLight(base.b, blend.b));
+}
+vec3 blendSoftLight(vec3 base, vec3 blend, float opacity) {
+  return (blendSoftLight(base, blend) * opacity + base * (1.0 - opacity));
+}
+float blendSubtract(float base, float blend) {
+  return max(base + blend - 1.0, 0.0);
+}
+vec3 blendSubtract(vec3 base, vec3 blend) {
+  return max(base + blend - vec3(1.0), vec3(0.0));
+}
+vec3 blendSubtract(vec3 base, vec3 blend, float opacity) {
+  return (blendSubtract(base, blend) * opacity + base * (1.0 - opacity));
+}
+vec3 blendExclusion(vec3 base, vec3 blend) {
+  return base + blend - 2.0 * base * blend;
+}
+vec3 blendExclusion(vec3 base, vec3 blend, float opacity) {
+  return (blendExclusion(base, blend) * opacity + base * (1.0 - opacity));
+}
+vec3 blendDifference(vec3 base, vec3 blend) { return abs(base - blend); }
+vec3 blendDifference(vec3 base, vec3 blend, float opacity) {
+  return (blendDifference(base, blend) * opacity + base * (1.0 - opacity));
+}
+float blendDarken(float base, float blend) { return min(blend, base); }
+vec3 blendDarken(vec3 base, vec3 blend) {
+  return vec3(blendDarken(base.r, blend.r), blendDarken(base.g, blend.g),
+              blendDarken(base.b, blend.b));
+}
+vec3 blendDarken(vec3 base, vec3 blend, float opacity) {
+  return (blendDarken(base, blend) * opacity + base * (1.0 - opacity));
+}
+float blendColorDodge(float base, float blend) {
+  return (blend == 1.0) ? blend : min(base / (1.0 - blend), 1.0);
+}
+vec3 blendColorDodge(vec3 base, vec3 blend) {
+  return vec3(blendColorDodge(base.r, blend.r),
+              blendColorDodge(base.g, blend.g),
+              blendColorDodge(base.b, blend.b));
+}
+vec3 blendColorDodge(vec3 base, vec3 blend, float opacity) {
+  return (blendColorDodge(base, blend) * opacity + base * (1.0 - opacity));
+}
+float blendColorBurn(float base, float blend) {
+  return (blend == 0.0) ? blend : max((1.0 - ((1.0 - base) / blend)), 0.0);
+}
+vec3 blendColorBurn(vec3 base, vec3 blend) {
+  return vec3(blendColorBurn(base.r, blend.r), blendColorBurn(base.g, blend.g),
+              blendColorBurn(base.b, blend.b));
+}
+vec3 blendColorBurn(vec3 base, vec3 blend, float opacity) {
+  return (blendColorBurn(base, blend) * opacity + base * (1.0 - opacity));
+}
+float blendAdd(float base, float blend) { return min(base + blend, 1.0); }
+vec3 blendAdd(vec3 base, vec3 blend) { return min(base + blend, vec3(1.0)); }
+vec3 blendAdd(vec3 base, vec3 blend, float opacity) {
+  return (blendAdd(base, blend) * opacity + base * (1.0 - opacity));
+}
+float blendLinearDodge(float base, float blend) {
+  return min(base + blend, 1.0);
+}
+vec3 blendLinearDodge(vec3 base, vec3 blend) {
+  return min(base + blend, vec3(1.0));
+}
+vec3 blendLinearDodge(vec3 base, vec3 blend, float opacity) {
+  return (blendLinearDodge(base, blend) * opacity + base * (1.0 - opacity));
+}
+vec3 blendHardLight(vec3 base, vec3 blend) { return blendOverlay(blend, base); }
+vec3 blendHardLight(vec3 base, vec3 blend, float opacity) {
+  return (blendHardLight(base, blend) * opacity + base * (1.0 - opacity));
+}
+vec3 blendGlow(vec3 base, vec3 blend) { return blendReflect(blend, base); }
+vec3 blendGlow(vec3 base, vec3 blend, float opacity) {
+  return (blendGlow(base, blend) * opacity + base * (1.0 - opacity));
+}
+float blendVividLight(float base, float blend) {
+  return (blend < 0.5) ? blendColorBurn(base, (2.0 * blend))
+                       : blendColorDodge(base, (2.0 * (blend - 0.5)));
+}
+vec3 blendVividLight(vec3 base, vec3 blend) {
+  return vec3(blendVividLight(base.r, blend.r),
+              blendVividLight(base.g, blend.g),
+              blendVividLight(base.b, blend.b));
+}
+vec3 blendVividLight(vec3 base, vec3 blend, float opacity) {
+  return (blendVividLight(base, blend) * opacity + base * (1.0 - opacity));
+}
+float blendHardMix(float base, float blend) {
+  return (blendVividLight(base, blend) < 0.5) ? 0.0 : 1.0;
+}
+vec3 blendHardMix(vec3 base, vec3 blend) {
+  return vec3(blendHardMix(base.r, blend.r), blendHardMix(base.g, blend.g),
+              blendHardMix(base.b, blend.b));
+}
+vec3 blendHardMix(vec3 base, vec3 blend, float opacity) {
+  return (blendHardMix(base, blend) * opacity + base * (1.0 - opacity));
+}
+float blendLinearLight(float base, float blend) {
+  return blend < 0.5 ? blendLinearBurn(base, (2.0 * blend))
+                     : blendLinearDodge(base, (2.0 * (blend - 0.5)));
+}
+vec3 blendLinearLight(vec3 base, vec3 blend) {
+  return vec3(blendLinearLight(base.r, blend.r),
+              blendLinearLight(base.g, blend.g),
+              blendLinearLight(base.b, blend.b));
+}
+vec3 blendLinearLight(vec3 base, vec3 blend, float opacity) {
+  return (blendLinearLight(base, blend) * opacity + base * (1.0 - opacity));
+}
+float blendPinLight(float base, float blend) {
+  return (blend < 0.5) ? blendDarken(base, (2.0 * blend))
+                       : blendLighten(base, (2.0 * (blend - 0.5)));
+}
+vec3 blendPinLight(vec3 base, vec3 blend) {
+  return vec3(blendPinLight(base.r, blend.r), blendPinLight(base.g, blend.g),
+              blendPinLight(base.b, blend.b));
+}
+vec3 blendPinLight(vec3 base, vec3 blend, float opacity) {
+  return (blendPinLight(base, blend) * opacity + base * (1.0 - opacity));
+}
+
+vec3 blendMode(int mode, vec3 base, vec3 blend) {
+  if (mode == 1) return blendAdd(base, blend);
+  else if (mode == 2) return blendAverage(base, blend);
+  else if (mode == 3) return blendColorBurn(base, blend);
+  else if (mode == 4) return blendColorDodge(base, blend);
+  else if (mode == 5) return blendDarken(base, blend);
+  else if (mode == 6) return blendDifference(base, blend);
+  else if (mode == 7) return blendExclusion(base, blend);
+  else if (mode == 8) return blendGlow(base, blend);
+  else if (mode == 9) return blendHardLight(base, blend);
+  else if (mode == 10) return blendHardMix(base, blend);
+  else if (mode == 11) return blendLighten(base, blend);
+  else if (mode == 12) return blendLinearBurn(base, blend);
+  else if (mode == 13) return blendLinearDodge(base, blend);
+  else if (mode == 14) return blendLinearLight(base, blend);
+  else if (mode == 15) return blendMultiply(base, blend);
+  else if (mode == 16) return blendNegation(base, blend);
+  else if (mode == 17) return blendNormal(base, blend);
+  else if (mode == 18) return blendOverlay(base, blend);
+  else if (mode == 19) return blendPhoenix(base, blend);
+  else if (mode == 20) return blendPinLight(base, blend);
+  else if (mode == 21) return blendReflect(base, blend);
+  else if (mode == 22) return blendScreen(base, blend);
+  else if (mode == 23) return blendSoftLight(base, blend);
+  else if (mode == 24) return blendSubtract(base, blend);
+  else if (mode == 25) return blendVividLight(base, blend);
+  else return vec3(0.,0.,0.);
+}
+
+vec3 blendMode(int mode, vec3 base, vec3 blend, float opacity) {
+  if (mode == 1) return blendAdd(base, blend, opacity);
+  else if (mode == 2) return blendAverage(base, blend, opacity);
+  else if (mode == 3) return blendColorBurn(base, blend, opacity);
+  else if (mode == 4) return blendColorDodge(base, blend, opacity);
+  else if (mode == 5) return blendDarken(base, blend, opacity);
+  else if (mode == 6) return blendDifference(base, blend, opacity);
+  else if (mode == 7) return blendExclusion(base, blend, opacity);
+  else if (mode == 8) return blendGlow(base, blend, opacity);
+  else if (mode == 9) return blendHardLight(base, blend, opacity);
+  else if (mode == 10) return blendHardMix(base, blend, opacity);
+  else if (mode == 11) return blendLighten(base, blend, opacity);
+  else if (mode == 12) return blendLinearBurn(base, blend, opacity);
+  else if (mode == 13) return blendLinearDodge(base, blend, opacity);
+  else if (mode == 14) return blendLinearLight(base, blend, opacity);
+  else if (mode == 15) return blendMultiply(base, blend, opacity);
+  else if (mode == 16) return blendNegation(base, blend, opacity);
+  else if (mode == 17) return blendNormal(base, blend, opacity);
+  else if (mode == 18) return blendOverlay(base, blend, opacity);
+  else if (mode == 19) return blendPhoenix(base, blend, opacity);
+  else if (mode == 20) return blendPinLight(base, blend, opacity);
+  else if (mode == 21) return blendReflect(base, blend, opacity);
+  else if (mode == 22) return blendScreen(base, blend, opacity);
+  else if (mode == 23) return blendSoftLight(base, blend, opacity);
+  else if (mode == 24) return blendSubtract(base, blend, opacity);
+  else if (mode == 25) return blendVividLight(base, blend, opacity);
+  else return vec3(0.,0.,0.);
+}
+
+void main() {
+    vec2 sample_uv = vv_FragNormCoord;
+    bool out_of_bounds = false;
+
+    // Aspect Ratio Correction Logic
+    if (keep_1_1_aspect) {
+        vec2 p_centered = (vv_FragNormCoord - 0.5) * 2.0;
+        float screen_aspect = RENDERSIZE.x / RENDERSIZE.y;
+        
+        if (screen_aspect > 1.0) { p_centered.x *= screen_aspect; }
+        else { p_centered.y /= screen_aspect; }
+        
+        sample_uv = (p_centered * 0.5) + 0.5;
+        
+        if (sample_uv.x < 0.0 || sample_uv.x > 1.0 || sample_uv.y < 0.0 || sample_uv.y > 1.0) {
+            out_of_bounds = true;
+        }
+    }
+
+    // Base Layer (t1)
+    vec4 s1 = vec4(0.0);
+    if (!out_of_bounds && alpha1 > 0.0) {
+        s1 = IMG_NORM_PIXEL(t1, sample_uv);
+    }
+    float a = s1.a * alpha1;
+    vec3 rgb = s1.rgb * a;
+    
+    // If we are out of bounds, we can just skip the rest and output transparency
+    if (out_of_bounds) {
+        gl_FragColor = vec4(0.0);
+        return;
+    }
+
+    // Layer 2
+    if (alpha2 > 0.0) {
+        vec4 s2 = IMG_NORM_PIXEL(t2, sample_uv);
+        float ea = s2.a * alpha2;
+        if (ea > 0.0) {
+            rgb = blendMode(mode1, rgb, s2.rgb, ea);
+            a = a + ea * (1.0 - a);
+        }
+    }
+
+    // Layer 3
+    if (alpha3 > 0.0) {
+        vec4 s3 = IMG_NORM_PIXEL(t3, sample_uv);
+        float ea = s3.a * alpha3;
+        if (ea > 0.0) {
+            rgb = blendMode(mode2, rgb, s3.rgb, ea);
+            a = a + ea * (1.0 - a);
+        }
+    }
+
+    // Layer 4
+    if (alpha4 > 0.0) {
+        vec4 s4 = IMG_NORM_PIXEL(t4, sample_uv);
+        float ea = s4.a * alpha4;
+        if (ea > 0.0) {
+            rgb = blendMode(mode3, rgb, s4.rgb, ea);
+            a = a + ea * (1.0 - a);
+        }
+    }
+
+    // Layer 5
+    if (alpha5 > 0.0) {
+        vec4 s5 = IMG_NORM_PIXEL(t5, sample_uv);
+        float ea = s5.a * alpha5;
+        if (ea > 0.0) {
+            rgb = blendMode(mode4, rgb, s5.rgb, ea);
+            a = a + ea * (1.0 - a);
+        }
+    }
+
+    // Layer 6
+    if (alpha6 > 0.0) {
+        vec4 s6 = IMG_NORM_PIXEL(t6, sample_uv);
+        float ea = s6.a * alpha6;
+        if (ea > 0.0) {
+            rgb = blendMode(mode5, rgb, s6.rgb, ea);
+            a = a + ea * (1.0 - a);
+        }
+    }
+
+    // Layer 7
+    if (alpha7 > 0.0) {
+        vec4 s7 = IMG_NORM_PIXEL(t7, sample_uv);
+        float ea = s7.a * alpha7;
+        if (ea > 0.0) {
+            rgb = blendMode(mode6, rgb, s7.rgb, ea);
+            a = a + ea * (1.0 - a);
+        }
+    }
+
+    // Layer 8
+    if (alpha8 > 0.0) {
+        vec4 s8 = IMG_NORM_PIXEL(t8, sample_uv);
+        float ea = s8.a * alpha8;
+        if (ea > 0.0) {
+            rgb = blendMode(mode7, rgb, s8.rgb, ea);
+            a = a + ea * (1.0 - a);
+        }
+    }
+
+    gl_FragColor = vec4(rgb, a);
+}

--- a/Presets/GLSL_shaders/fulldome/domemaster_mask.fs
+++ b/Presets/GLSL_shaders/fulldome/domemaster_mask.fs
@@ -1,0 +1,67 @@
+/*{
+    "DESCRIPTION": "Applies a customizable Domemaster mask defined by a polar angle range, a color, and a feathered edge (softness). Assumes the input is a 210-degree FOV Domemaster projection.",
+    "CREDIT": "AI Assistant (Gemini)",
+    "CATEGORIES": [
+        "TRANSFORM",
+        "DOME",
+        "MASK"
+    ],
+    "INPUTS": [
+        { "NAME": "inputImage", "TYPE": "image", "LABEL": "Domemaster Input" },
+        { "NAME": "keep_1_1_aspect", "LABEL": "Keep 1:1 Input Aspect", "TYPE": "bool", "DEFAULT": true },
+        { "NAME": "mask_polar_angle_degrees", "LABEL": "Mask Polar Angle Degrees (0 to 60)", "TYPE": "float", "DEFAULT": 14.0, "MIN": 0.0, "MAX": 60.0 },
+        { "NAME": "mask_softness_degrees", "LABEL": "Mask Softness (Feathering Degrees)", "TYPE": "float", "DEFAULT": 1.0, "MIN": 0.0, "MAX": 30.0 },
+        { "NAME": "mask_color", "LABEL": "Mask Color (incl. Alpha)", "TYPE": "color", "DEFAULT": [0.0, 0.0, 0.0, 1.0] }
+    ]
+}*/
+
+// Mathematical constants
+#define M_PI 3.14159265359
+
+void main() {
+    // 1. Normalize and center the fragment coordinates to [-1, 1]
+    vec2 p_centered = (vv_FragNormCoord - 0.5) * 2.0;
+
+    // 2. Correct for aspect ratio to keep math perfectly circular
+    float screen_aspect = RENDERSIZE.x / RENDERSIZE.y;
+    if (screen_aspect > 1.0) { p_centered.x *= screen_aspect; }
+    else { p_centered.y /= screen_aspect; }
+
+    // 3. Sample the input image
+    vec4 source_color;
+    if (keep_1_1_aspect) {
+        // Un-center the corrected coordinates back to [0, 1] UV space
+        vec2 sample_uv = (p_centered * 0.5) + 0.5;
+        
+        // Prevent repeating/smearing outside the 1:1 image bounds
+        if (sample_uv.x < 0.0 || sample_uv.x > 1.0 || sample_uv.y < 0.0 || sample_uv.y > 1.0) {
+            source_color = vec4(0.0); 
+        } else {
+            source_color = IMG_NORM_PIXEL(inputImage, sample_uv);
+        }
+    } else {
+        // Default behavior (maps texture to full window bounds)
+        source_color = IMG_THIS_PIXEL(inputImage);
+    }
+
+    // 4. Calculate the distance from the center (normalized radius)
+    float dist_from_center = length(p_centered);
+
+    // --- Uniform Calculations ---
+    float half_fov_degrees = 105.0; 
+    float mask_start_polar_angle = half_fov_degrees - mask_polar_angle_degrees;
+    float fade_start_polar_angle = mask_start_polar_angle - mask_softness_degrees;
+    
+    float fade_end_radius = mask_start_polar_angle / half_fov_degrees; 
+    float fade_start_radius = fade_start_polar_angle / half_fov_degrees; 
+    fade_start_radius = max(0.0, fade_start_radius); 
+    
+    // --- Masking Logic ---
+    if (dist_from_center > 1.0) {
+        isf_FragColor = mask_color; 
+        return;
+    }
+
+    float mask_factor = smoothstep(fade_start_radius, fade_end_radius, dist_from_center);
+    isf_FragColor = mix(source_color, mask_color, mask_factor);
+}

--- a/Presets/GLSL_shaders/fulldome/half_cubesides_to_domemaster.fs
+++ b/Presets/GLSL_shaders/fulldome/half_cubesides_to_domemaster.fs
@@ -1,0 +1,158 @@
+/*{
+    "DESCRIPTION": "Optimized single-pass Domemaster. Maps raw 2:1 images to top/bottom halves, rotating bottom 180. Includes API-level input flips.",
+    "CREDIT": "Edu Meneses + AI Assistant (Gemini)",
+    "CATEGORIES": [
+        "GENERATOR",
+        "3D",
+        "DOME"
+    ],
+    "INPUTS": [
+        { "NAME": "facePosX_Top", "TYPE": "image", "LABEL": "+X Side (Top Image)" },
+        { "NAME": "facePosX_Bot", "TYPE": "image", "LABEL": "+X Side (Bottom Image - 180 Rot)" },
+        { "NAME": "faceNegX_Top", "TYPE": "image", "LABEL": "-X Side (Top Image)" },
+        { "NAME": "faceNegX_Bot", "TYPE": "image", "LABEL": "-X Side (Bottom Image - 180 Rot)" },
+        { "NAME": "facePosZ_Top", "TYPE": "image", "LABEL": "+Z Side (Front Top)" },
+        { "NAME": "facePosZ_Bot", "TYPE": "image", "LABEL": "+Z Side (Front Bottom - 180 Rot)" },
+        { "NAME": "faceNegZ_Top", "TYPE": "image", "LABEL": "-Z Side (Back Top)" },
+        { "NAME": "faceNegZ_Bot", "TYPE": "image", "LABEL": "-Z Side (Back Bottom - 180 Rot)" },
+        { "NAME": "facePosY", "TYPE": "image", "LABEL": "+Y Pole (Zenith/Ceiling)" },
+        { "NAME": "faceNegY", "TYPE": "image", "LABEL": "-Y Pole (Nadir/Floor)" },
+        { "NAME": "alpha1", "LABEL": "Alpha (Top Imgs)", "TYPE": "float", "MIN": 0.0, "MAX": 1.0, "DEFAULT": 1.0 },
+        { "NAME": "alpha2", "LABEL": "Alpha (Bottom Imgs)", "TYPE": "float", "MIN": 0.0, "MAX": 1.0, "DEFAULT": 1.0 },
+        { "NAME": "rotate_x", "LABEL": "Rotate X (0-1, Yaw)", "TYPE": "float", "DEFAULT": 0.5, "MIN": 0.0, "MAX": 1.0 },
+        { "NAME": "rotate_y", "LABEL": "Rotate Y (0-1, Pitch)", "TYPE": "float", "DEFAULT": 0.5, "MIN": 0.0, "MAX": 1.0 },
+        { "NAME": "rotate_z", "LABEL": "Rotate Z (0-1, Roll)", "TYPE": "float", "DEFAULT": 0.5, "MIN": 0.0, "MAX": 1.0 },
+        { "NAME": "domemaster_output_fov_degrees", "LABEL": "Domemaster Output FOV", "TYPE": "float", "DEFAULT": 180.0, "MIN": 1.0, "MAX": 360.0 },
+        { "NAME": "flip_input_x", "LABEL": "Flip Inputs Horizontally", "TYPE": "bool", "DEFAULT": false },
+        { "NAME": "flip_input_y", "LABEL": "Flip Inputs Vertically (GL/VK)", "TYPE": "bool", "DEFAULT": false }
+    ],
+    "ISFVSN": "2"
+}*/
+
+#define M_PI 3.14159265359
+#define TWO_PI 6.28318530718
+
+// Creates a rotation matrix from Euler angles (Yaw, Pitch, Roll).
+mat3 makeRotationMatrix(vec3 euler_angles) {
+    float cos_yaw   = cos(euler_angles.x); float sin_yaw   = sin(euler_angles.x);
+    float cos_pitch = cos(euler_angles.y); float sin_pitch = sin(euler_angles.y);
+    float cos_roll  = cos(euler_angles.z); float sin_roll  = sin(euler_angles.z);
+
+    return mat3(
+        cos_yaw * cos_roll - sin_yaw * cos_pitch * sin_roll,
+        -cos_yaw * sin_roll - sin_yaw * cos_pitch * cos_roll,
+        sin_yaw * sin_pitch,
+        sin_yaw * cos_roll + cos_yaw * cos_pitch * sin_roll,
+        -sin_yaw * sin_roll + cos_yaw * cos_pitch * cos_roll,
+        -cos_yaw * sin_pitch,
+        sin_pitch * sin_roll,
+        sin_pitch * cos_roll,
+        cos_pitch
+    );
+}
+
+// Helper to correct UVs based on the graphics API or mirroring needs
+vec2 flipUV(vec2 uv) {
+    vec2 flipped = uv;
+    if (flip_input_x) flipped.x = 1.0 - flipped.x;
+    if (flip_input_y) flipped.y = 1.0 - flipped.y;
+    return flipped;
+}
+
+void main() {
+    // --- Center and aspect ratio correction ---
+    vec2 p_centered = (vv_FragNormCoord - 0.5) * 2.0;
+    float screen_aspect = RENDERSIZE.x / RENDERSIZE.y;
+    if (screen_aspect > 1.0) { p_centered.x *= screen_aspect; }
+    else { p_centered.y /= screen_aspect; }
+
+    // --- Circular Domemaster Mask ---
+    float dist_from_center = length(p_centered);
+    if (dist_from_center > 1.0) {
+        isf_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
+        return;
+    }
+
+    // --- Projection Calculations ---
+    float yaw   = rotate_x * TWO_PI;
+    float pitch = rotate_y * M_PI;
+    float roll  = rotate_z * TWO_PI;
+    mat3 inverse_content_rotation_matrix = transpose(makeRotationMatrix(vec3(yaw, pitch, roll)));
+    float fisheye_half_fov_rad = domemaster_output_fov_degrees * (M_PI / 360.0);
+    
+    float ray_polar_angle = dist_from_center * fisheye_half_fov_rad;
+    float ray_azimuth_angle = atan(p_centered.y, p_centered.x);
+
+    vec3 ray_dir_world = vec3(
+        sin(ray_polar_angle) * cos(ray_azimuth_angle),
+        sin(ray_polar_angle) * sin(ray_azimuth_angle),
+        cos(ray_polar_angle)
+    );
+    vec3 local_ray_dir = inverse_content_rotation_matrix * ray_dir_world;
+
+    // --- Target Face Selection & Spatial Mapping ---
+    vec3 v_abs = abs(local_ray_dir);
+    vec2 sc_tc, final_uv;
+    vec4 sampled_color = vec4(0.0);
+
+    // Helper macro to calculate base UVs from cube coordinates
+    #define CALC_FINAL_UV(coord) ((coord * vec2(-1.0, -1.0) + 1.0) * 0.5)
+
+    if (v_abs.x >= v_abs.y && v_abs.x >= v_abs.z) { // Hit X Axis (Sides)
+        if (local_ray_dir.x > 0.0) { // +X Right
+            sc_tc = vec2(-local_ray_dir.z, -local_ray_dir.y) / v_abs.x;
+            final_uv = CALC_FINAL_UV(sc_tc);
+            if (final_uv.y >= 0.5) {
+                sampled_color = IMG_NORM_PIXEL(facePosX_Top, flipUV(vec2(final_uv.x, (final_uv.y - 0.5) * 2.0)));
+                sampled_color.rgb *= alpha1;
+            } else {
+                sampled_color = IMG_NORM_PIXEL(facePosX_Bot, flipUV(vec2(1.0 - final_uv.x, 1.0 - (final_uv.y * 2.0))));
+                sampled_color.rgb *= alpha2;
+            }
+        } else { // -X Left
+            sc_tc = vec2(local_ray_dir.z, -local_ray_dir.y) / v_abs.x;
+            final_uv = CALC_FINAL_UV(sc_tc);
+            if (final_uv.y >= 0.5) {
+                sampled_color = IMG_NORM_PIXEL(faceNegX_Top, flipUV(vec2(final_uv.x, (final_uv.y - 0.5) * 2.0)));
+                sampled_color.rgb *= alpha1;
+            } else {
+                sampled_color = IMG_NORM_PIXEL(faceNegX_Bot, flipUV(vec2(1.0 - final_uv.x, 1.0 - (final_uv.y * 2.0))));
+                sampled_color.rgb *= alpha2;
+            }
+        }
+    } else if (v_abs.y >= v_abs.z) { // Hit Y Axis (Top/Bottom Poles)
+        if (local_ray_dir.y > 0.0) { // +Y Top Pole
+            sc_tc = vec2(local_ray_dir.x, local_ray_dir.z) / v_abs.y;
+            final_uv = CALC_FINAL_UV(sc_tc);
+            sampled_color = IMG_NORM_PIXEL(facePosY, flipUV(final_uv));
+        } else { // -Y Bottom Pole
+            sc_tc = vec2(local_ray_dir.x, -local_ray_dir.z) / v_abs.y;
+            final_uv = CALC_FINAL_UV(sc_tc);
+            sampled_color = IMG_NORM_PIXEL(faceNegY, flipUV(final_uv));
+        }
+    } else { // Hit Z Axis (Sides)
+        if (local_ray_dir.z > 0.0) { // +Z Front
+            sc_tc = vec2(local_ray_dir.x, -local_ray_dir.y) / v_abs.z;
+            final_uv = CALC_FINAL_UV(sc_tc);
+            if (final_uv.y >= 0.5) {
+                sampled_color = IMG_NORM_PIXEL(facePosZ_Top, flipUV(vec2(final_uv.x, (final_uv.y - 0.5) * 2.0)));
+                sampled_color.rgb *= alpha1;
+            } else {
+                sampled_color = IMG_NORM_PIXEL(facePosZ_Bot, flipUV(vec2(1.0 - final_uv.x, 1.0 - (final_uv.y * 2.0))));
+                sampled_color.rgb *= alpha2;
+            }
+        } else { // -Z Back
+            sc_tc = vec2(-local_ray_dir.x, -local_ray_dir.y) / v_abs.z;
+            final_uv = CALC_FINAL_UV(sc_tc);
+            if (final_uv.y >= 0.5) {
+                sampled_color = IMG_NORM_PIXEL(faceNegZ_Top, flipUV(vec2(final_uv.x, (final_uv.y - 0.5) * 2.0)));
+                sampled_color.rgb *= alpha1;
+            } else {
+                sampled_color = IMG_NORM_PIXEL(faceNegZ_Bot, flipUV(vec2(1.0 - final_uv.x, 1.0 - (final_uv.y * 2.0))));
+                sampled_color.rgb *= alpha2;
+            }
+        }
+    }
+
+    isf_FragColor = sampled_color;
+}

--- a/Presets/GLSL_shaders/fulldome/hexagonal_faces_to_domemaster.fs
+++ b/Presets/GLSL_shaders/fulldome/hexagonal_faces_to_domemaster.fs
@@ -1,0 +1,179 @@
+/*{
+    "DESCRIPTION": "Hexagonal Prism Domemaster. 6 side faces (split into top/bottom halves, bottom rotated 180) + 2 pole faces. Preserves transparency.",
+    "CREDIT": "Edu Meneses + AI Assistant (Gemini)",
+    "CATEGORIES": [
+        "GENERATOR",
+        "3D",
+        "DOME"
+    ],
+    "INPUTS": [
+        { "NAME": "side1_Top", "TYPE": "image", "LABEL": "Side 1 Top (0°)" },
+        { "NAME": "side1_Bot", "TYPE": "image", "LABEL": "Side 1 Bot (0° - 180 Rot)" },
+        { "NAME": "side2_Top", "TYPE": "image", "LABEL": "Side 2 Top (60°)" },
+        { "NAME": "side2_Bot", "TYPE": "image", "LABEL": "Side 2 Bot (60° - 180 Rot)" },
+        { "NAME": "side3_Top", "TYPE": "image", "LABEL": "Side 3 Top (120°)" },
+        { "NAME": "side3_Bot", "TYPE": "image", "LABEL": "Side 3 Bot (120° - 180 Rot)" },
+        { "NAME": "side4_Top", "TYPE": "image", "LABEL": "Side 4 Top (180°)" },
+        { "NAME": "side4_Bot", "TYPE": "image", "LABEL": "Side 4 Bot (180° - 180 Rot)" },
+        { "NAME": "side5_Top", "TYPE": "image", "LABEL": "Side 5 Top (240°)" },
+        { "NAME": "side5_Bot", "TYPE": "image", "LABEL": "Side 5 Bot (240° - 180 Rot)" },
+        { "NAME": "side6_Top", "TYPE": "image", "LABEL": "Side 6 Top (300°)" },
+        { "NAME": "side6_Bot", "TYPE": "image", "LABEL": "Side 6 Bot (300° - 180 Rot)" },
+        { "NAME": "poleTop", "TYPE": "image", "LABEL": "Top Pole (+Y Zenith)" },
+        { "NAME": "poleBot", "TYPE": "image", "LABEL": "Bottom Pole (-Y Nadir)" },
+        { "NAME": "alpha1", "LABEL": "Alpha (Top Imgs)", "TYPE": "float", "MIN": 0.0, "MAX": 1.0, "DEFAULT": 1.0 },
+        { "NAME": "alpha2", "LABEL": "Alpha (Bottom Imgs)", "TYPE": "float", "MIN": 0.0, "MAX": 1.0, "DEFAULT": 1.0 },
+        { "NAME": "rotate_x", "LABEL": "Rotate X (0-1, Yaw)", "TYPE": "float", "DEFAULT": 0.5, "MIN": 0.0, "MAX": 1.0 },
+        { "NAME": "rotate_y", "LABEL": "Rotate Y (0-1, Pitch)", "TYPE": "float", "DEFAULT": 0.5, "MIN": 0.0, "MAX": 1.0 },
+        { "NAME": "rotate_z", "LABEL": "Rotate Z (0-1, Roll)", "TYPE": "float", "DEFAULT": 0.5, "MIN": 0.0, "MAX": 1.0 },
+        { "NAME": "domemaster_output_fov_degrees", "LABEL": "Domemaster Output FOV", "TYPE": "float", "DEFAULT": 180.0, "MIN": 1.0, "MAX": 360.0 },
+        { "NAME": "flip_input_x", "LABEL": "Flip Inputs Horizontally", "TYPE": "bool", "DEFAULT": false },
+        { "NAME": "flip_input_y", "LABEL": "Flip Inputs Vertically (GL/VK)", "TYPE": "bool", "DEFAULT": false }
+    ],
+    "ISFVSN": "2"
+}*/
+
+#define M_PI 3.14159265359
+#define TWO_PI 6.28318530718
+#define TAN_30 0.57735026919
+#define HEX_CORNER_RADIUS 1.15470053839
+
+// Creates a rotation matrix from Euler angles (Yaw, Pitch, Roll).
+mat3 makeRotationMatrix(vec3 euler_angles) {
+    float cos_yaw   = cos(euler_angles.x); float sin_yaw   = sin(euler_angles.x);
+    float cos_pitch = cos(euler_angles.y); float sin_pitch = sin(euler_angles.y);
+    float cos_roll  = cos(euler_angles.z); float sin_roll  = sin(euler_angles.z);
+
+    return mat3(
+        cos_yaw * cos_roll - sin_yaw * cos_pitch * sin_roll,
+        -cos_yaw * sin_roll - sin_yaw * cos_pitch * cos_roll,
+        sin_yaw * sin_pitch,
+        sin_yaw * cos_roll + cos_yaw * cos_pitch * sin_roll,
+        -sin_yaw * sin_roll + cos_yaw * cos_pitch * cos_roll,
+        -cos_yaw * sin_pitch,
+        sin_pitch * sin_roll,
+        sin_pitch * cos_roll,
+        cos_pitch
+    );
+}
+
+// Helper to correct UVs based on the graphics API or mirroring needs
+vec2 flipUV(vec2 uv) {
+    vec2 flipped = uv;
+    if (flip_input_x) flipped.x = 1.0 - flipped.x;
+    if (flip_input_y) flipped.y = 1.0 - flipped.y;
+    return flipped;
+}
+
+void main() {
+    // --- Center and aspect ratio correction ---
+    vec2 p_centered = (vv_FragNormCoord - 0.5) * 2.0;
+    float screen_aspect = RENDERSIZE.x / RENDERSIZE.y;
+    if (screen_aspect > 1.0) { p_centered.x *= screen_aspect; }
+    else { p_centered.y /= screen_aspect; }
+
+    // --- Circular Domemaster Mask ---
+    float dist_from_center = length(p_centered);
+    if (dist_from_center > 1.0) {
+        isf_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
+        return;
+    }
+
+    // --- Projection Calculations ---
+    float yaw   = rotate_x * TWO_PI;
+    float pitch = rotate_y * M_PI;
+    float roll  = rotate_z * TWO_PI;
+    mat3 inverse_content_rotation_matrix = transpose(makeRotationMatrix(vec3(yaw, pitch, roll)));
+    float fisheye_half_fov_rad = domemaster_output_fov_degrees * (M_PI / 360.0);
+    
+    float ray_polar_angle = dist_from_center * fisheye_half_fov_rad;
+    float ray_azimuth_angle = atan(p_centered.y, p_centered.x);
+
+    vec3 ray_dir_world = vec3(
+        sin(ray_polar_angle) * cos(ray_azimuth_angle),
+        sin(ray_polar_angle) * sin(ray_azimuth_angle),
+        cos(ray_polar_angle)
+    );
+    vec3 local_ray_dir = inverse_content_rotation_matrix * ray_dir_world;
+
+    // --- Target Face Selection for Hexagonal Prism ---
+    vec3 dir = local_ray_dir;
+    
+    // 1. Find angle around the Y axis
+    float theta = atan(dir.z, dir.x);
+    if (theta < 0.0) theta += TWO_PI;
+    
+    // 2. Determine which of the 6 faces we hit (offset by 30 deg so face 0 is centered on X)
+    float face_idx = floor((theta + M_PI / 6.0) / (M_PI / 3.0));
+    if (face_idx >= 6.0) face_idx -= 6.0;
+    
+    // 3. Calculate the normal of that face
+    float phi = face_idx * (M_PI / 3.0);
+    vec3 N = vec3(cos(phi), 0.0, sin(phi));
+    
+    // 4. Ray-plane intersection distances
+    float t_side = 1.0 / dot(N, dir); // Distance to the hex wall
+    float t_y = 1.0 / abs(dir.y);     // Distance to the top/bot caps
+
+    vec2 final_uv;
+    vec4 sampled_color = vec4(0.0);
+
+    if (t_side < t_y) {
+        // --- Hit one of the 6 Side Faces ---
+        vec3 P = dir * t_side;
+        vec3 T = vec3(-sin(phi), 0.0, cos(phi)); // Tangent vector along the face
+        
+        float u = dot(P, T); // Ranges from -TAN_30 to +TAN_30
+        float v = P.y;       // Ranges from -1.0 to 1.0
+        
+        // Map to 0.0 -> 1.0 UV space
+        final_uv.x = (u / TAN_30 + 1.0) * 0.5;
+        final_uv.y = (v + 1.0) * 0.5;
+        
+        int idx = int(face_idx);
+        
+        // Split logic: Top half vs Bottom half (180 rotated)
+        if (final_uv.y >= 0.5) {
+            vec2 top_uv = flipUV(vec2(final_uv.x, (final_uv.y - 0.5) * 2.0));
+            
+            if (idx == 0)      sampled_color = IMG_NORM_PIXEL(side1_Top, top_uv);
+            else if (idx == 1) sampled_color = IMG_NORM_PIXEL(side6_Top, top_uv);
+            else if (idx == 2) sampled_color = IMG_NORM_PIXEL(side5_Top, top_uv);
+            else if (idx == 3) sampled_color = IMG_NORM_PIXEL(side4_Top, top_uv);
+            else if (idx == 4) sampled_color = IMG_NORM_PIXEL(side3_Top, top_uv);
+            else               sampled_color = IMG_NORM_PIXEL(side2_Top, top_uv);
+            
+            sampled_color.rgb *= alpha1; // Fade to black preserving transparency
+        } else {
+            vec2 bot_uv = flipUV(vec2(1.0 - final_uv.x, 1.0 - (final_uv.y * 2.0)));
+            
+            if (idx == 0)      sampled_color = IMG_NORM_PIXEL(side1_Bot, bot_uv);
+            else if (idx == 1) sampled_color = IMG_NORM_PIXEL(side6_Bot, bot_uv);
+            else if (idx == 2) sampled_color = IMG_NORM_PIXEL(side5_Bot, bot_uv);
+            else if (idx == 3) sampled_color = IMG_NORM_PIXEL(side4_Bot, bot_uv);
+            else if (idx == 4) sampled_color = IMG_NORM_PIXEL(side3_Bot, bot_uv);
+            else               sampled_color = IMG_NORM_PIXEL(side2_Bot, bot_uv);
+            
+            sampled_color.rgb *= alpha2; // Fade to black preserving transparency
+        }
+        
+    } else {
+        // --- Hit Top or Bottom Pole ---
+        vec3 P = dir * t_y;
+        
+        // The hex corners extend to 1.1547. Dividing by this value guarantees 
+        // the hexagon fits entirely inside the square input, discarding the corners.
+        final_uv.x = (P.x / HEX_CORNER_RADIUS + 1.0) * 0.5;
+        final_uv.y = (P.z / HEX_CORNER_RADIUS + 1.0) * 0.5;
+        final_uv = flipUV(final_uv);
+        
+        if (dir.y > 0.0) {
+            sampled_color = IMG_NORM_PIXEL(poleTop, final_uv);
+        } else {
+            sampled_color = IMG_NORM_PIXEL(poleBot, final_uv);
+        }
+    }
+
+    // Preserve the original input alpha
+    isf_FragColor = sampled_color;
+}

--- a/Presets/GLSL_shaders/utility/Video Mixer.fs
+++ b/Presets/GLSL_shaders/utility/Video Mixer.fs
@@ -2,8 +2,8 @@
     "CATEGORIES": [
         "General"
     ],
-    "CREDIT": "Jamie Owen, Jean-Michaël Celerier",
-    "DESCRIPTION": "8-channel video mixer",
+    "CREDIT": "Jamie Owen, Jean-Michaël Celerier, Optimized by AI Assistant (Gemini)",
+    "DESCRIPTION": "8-channel video mixer (Optimized)",
     "INPUTS": [
         { "NAME": "t1", "LABEL" : "Texture 1", "TYPE": "image" },
         { "NAME": "t2", "LABEL" : "Texture 2", "TYPE": "image" },
@@ -104,452 +104,228 @@
 */
 
 /* Blend mode implementations courtesy of Jamie Owen:
-
    https://github.com/jamieowen/glsl-blend
-
-The MIT License (MIT) Copyright (c) 2015 Jamie Owen
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 */
+
 vec3 blendPhoenix(vec3 base, vec3 blend) {
   return min(base, blend) - max(base, blend) + vec3(1.0);
 }
-
-vec3 blendPhoenix(vec3 base, vec3 blend, float opacity) {
-  return (blendPhoenix(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 float blendOverlay(float base, float blend) {
-  return base < 0.5 ? (2.0 * base * blend)
-                    : (1.0 - 2.0 * (1.0 - base) * (1.0 - blend));
+  return base < 0.5 ? (2.0 * base * blend) : (1.0 - 2.0 * (1.0 - base) * (1.0 - blend));
 }
-
 vec3 blendOverlay(vec3 base, vec3 blend) {
-  return vec3(blendOverlay(base.r, blend.r), blendOverlay(base.g, blend.g),
-              blendOverlay(base.b, blend.b));
+  return vec3(blendOverlay(base.r, blend.r), blendOverlay(base.g, blend.g), blendOverlay(base.b, blend.b));
 }
-
-vec3 blendOverlay(vec3 base, vec3 blend, float opacity) {
-  return (blendOverlay(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 vec3 blendNormal(vec3 base, vec3 blend) { return blend; }
-
-vec3 blendNormal(vec3 base, vec3 blend, float opacity) {
-  return (blendNormal(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 vec3 blendNegation(vec3 base, vec3 blend) {
   return vec3(1.0) - abs(vec3(1.0) - base - blend);
 }
-
-vec3 blendNegation(vec3 base, vec3 blend, float opacity) {
-  return (blendNegation(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 vec3 blendMultiply(vec3 base, vec3 blend) { return base * blend; }
-
-vec3 blendMultiply(vec3 base, vec3 blend, float opacity) {
-  return (blendMultiply(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 float blendReflect(float base, float blend) {
   return (blend == 1.0) ? blend : min(base * base / (1.0 - blend), 1.0);
 }
-
 vec3 blendReflect(vec3 base, vec3 blend) {
-  return vec3(blendReflect(base.r, blend.r), blendReflect(base.g, blend.g),
-              blendReflect(base.b, blend.b));
+  return vec3(blendReflect(base.r, blend.r), blendReflect(base.g, blend.g), blendReflect(base.b, blend.b));
 }
-
-vec3 blendReflect(vec3 base, vec3 blend, float opacity) {
-  return (blendReflect(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 vec3 blendAverage(vec3 base, vec3 blend) { return (base + blend) / 2.0; }
-
-vec3 blendAverage(vec3 base, vec3 blend, float opacity) {
-  return (blendAverage(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 float blendLinearBurn(float base, float blend) {
-  // Note : Same implementation as BlendSubtractf
   return max(base + blend - 1.0, 0.0);
 }
-
 vec3 blendLinearBurn(vec3 base, vec3 blend) {
-  // Note : Same implementation as BlendSubtract
   return max(base + blend - vec3(1.0), vec3(0.0));
 }
-
-vec3 blendLinearBurn(vec3 base, vec3 blend, float opacity) {
-  return (blendLinearBurn(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 float blendLighten(float base, float blend) { return max(blend, base); }
-
 vec3 blendLighten(vec3 base, vec3 blend) {
-  return vec3(blendLighten(base.r, blend.r), blendLighten(base.g, blend.g),
-              blendLighten(base.b, blend.b));
+  return vec3(blendLighten(base.r, blend.r), blendLighten(base.g, blend.g), blendLighten(base.b, blend.b));
 }
-
-vec3 blendLighten(vec3 base, vec3 blend, float opacity) {
-  return (blendLighten(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 float blendScreen(float base, float blend) {
   return 1.0 - ((1.0 - base) * (1.0 - blend));
 }
-
 vec3 blendScreen(vec3 base, vec3 blend) {
-  return vec3(blendScreen(base.r, blend.r), blendScreen(base.g, blend.g),
-              blendScreen(base.b, blend.b));
+  return vec3(blendScreen(base.r, blend.r), blendScreen(base.g, blend.g), blendScreen(base.b, blend.b));
 }
-
-vec3 blendScreen(vec3 base, vec3 blend, float opacity) {
-  return (blendScreen(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 float blendSoftLight(float base, float blend) {
   return (blend < 0.5)
              ? (2.0 * base * blend + base * base * (1.0 - 2.0 * blend))
              : (sqrt(base) * (2.0 * blend - 1.0) + 2.0 * base * (1.0 - blend));
 }
-
 vec3 blendSoftLight(vec3 base, vec3 blend) {
-  return vec3(blendSoftLight(base.r, blend.r), blendSoftLight(base.g, blend.g),
-              blendSoftLight(base.b, blend.b));
+  return vec3(blendSoftLight(base.r, blend.r), blendSoftLight(base.g, blend.g), blendSoftLight(base.b, blend.b));
 }
-
-vec3 blendSoftLight(vec3 base, vec3 blend, float opacity) {
-  return (blendSoftLight(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 float blendSubtract(float base, float blend) {
   return max(base + blend - 1.0, 0.0);
 }
-
 vec3 blendSubtract(vec3 base, vec3 blend) {
   return max(base + blend - vec3(1.0), vec3(0.0));
 }
-
-vec3 blendSubtract(vec3 base, vec3 blend, float opacity) {
-  return (blendSubtract(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 vec3 blendExclusion(vec3 base, vec3 blend) {
   return base + blend - 2.0 * base * blend;
 }
-
-vec3 blendExclusion(vec3 base, vec3 blend, float opacity) {
-  return (blendExclusion(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 vec3 blendDifference(vec3 base, vec3 blend) { return abs(base - blend); }
-
-vec3 blendDifference(vec3 base, vec3 blend, float opacity) {
-  return (blendDifference(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 float blendDarken(float base, float blend) { return min(blend, base); }
-
 vec3 blendDarken(vec3 base, vec3 blend) {
-  return vec3(blendDarken(base.r, blend.r), blendDarken(base.g, blend.g),
-              blendDarken(base.b, blend.b));
+  return vec3(blendDarken(base.r, blend.r), blendDarken(base.g, blend.g), blendDarken(base.b, blend.b));
 }
-
-vec3 blendDarken(vec3 base, vec3 blend, float opacity) {
-  return (blendDarken(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 float blendColorDodge(float base, float blend) {
   return (blend == 1.0) ? blend : min(base / (1.0 - blend), 1.0);
 }
-
 vec3 blendColorDodge(vec3 base, vec3 blend) {
-  return vec3(blendColorDodge(base.r, blend.r),
-              blendColorDodge(base.g, blend.g),
-              blendColorDodge(base.b, blend.b));
+  return vec3(blendColorDodge(base.r, blend.r), blendColorDodge(base.g, blend.g), blendColorDodge(base.b, blend.b));
 }
-
-vec3 blendColorDodge(vec3 base, vec3 blend, float opacity) {
-  return (blendColorDodge(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 float blendColorBurn(float base, float blend) {
   return (blend == 0.0) ? blend : max((1.0 - ((1.0 - base) / blend)), 0.0);
 }
-
 vec3 blendColorBurn(vec3 base, vec3 blend) {
-  return vec3(blendColorBurn(base.r, blend.r), blendColorBurn(base.g, blend.g),
-              blendColorBurn(base.b, blend.b));
+  return vec3(blendColorBurn(base.r, blend.r), blendColorBurn(base.g, blend.g), blendColorBurn(base.b, blend.b));
 }
-
-vec3 blendColorBurn(vec3 base, vec3 blend, float opacity) {
-  return (blendColorBurn(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 float blendAdd(float base, float blend) { return min(base + blend, 1.0); }
-
 vec3 blendAdd(vec3 base, vec3 blend) { return min(base + blend, vec3(1.0)); }
-
-vec3 blendAdd(vec3 base, vec3 blend, float opacity) {
-  return (blendAdd(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 float blendLinearDodge(float base, float blend) {
-  // Note : Same implementation as BlendAddf
   return min(base + blend, 1.0);
 }
-
 vec3 blendLinearDodge(vec3 base, vec3 blend) {
-  // Note : Same implementation as BlendAdd
   return min(base + blend, vec3(1.0));
 }
-
-vec3 blendLinearDodge(vec3 base, vec3 blend, float opacity) {
-  return (blendLinearDodge(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 vec3 blendHardLight(vec3 base, vec3 blend) { return blendOverlay(blend, base); }
-
-vec3 blendHardLight(vec3 base, vec3 blend, float opacity) {
-  return (blendHardLight(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 vec3 blendGlow(vec3 base, vec3 blend) { return blendReflect(blend, base); }
-
-vec3 blendGlow(vec3 base, vec3 blend, float opacity) {
-  return (blendGlow(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 float blendVividLight(float base, float blend) {
-  return (blend < 0.5) ? blendColorBurn(base, (2.0 * blend))
-                       : blendColorDodge(base, (2.0 * (blend - 0.5)));
+  return (blend < 0.5) ? blendColorBurn(base, (2.0 * blend)) : blendColorDodge(base, (2.0 * (blend - 0.5)));
 }
-
 vec3 blendVividLight(vec3 base, vec3 blend) {
-  return vec3(blendVividLight(base.r, blend.r),
-              blendVividLight(base.g, blend.g),
-              blendVividLight(base.b, blend.b));
+  return vec3(blendVividLight(base.r, blend.r), blendVividLight(base.g, blend.g), blendVividLight(base.b, blend.b));
 }
-
-vec3 blendVividLight(vec3 base, vec3 blend, float opacity) {
-  return (blendVividLight(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 float blendHardMix(float base, float blend) {
   return (blendVividLight(base, blend) < 0.5) ? 0.0 : 1.0;
 }
-
 vec3 blendHardMix(vec3 base, vec3 blend) {
-  return vec3(blendHardMix(base.r, blend.r), blendHardMix(base.g, blend.g),
-              blendHardMix(base.b, blend.b));
+  return vec3(blendHardMix(base.r, blend.r), blendHardMix(base.g, blend.g), blendHardMix(base.b, blend.b));
 }
-
-vec3 blendHardMix(vec3 base, vec3 blend, float opacity) {
-  return (blendHardMix(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 float blendLinearLight(float base, float blend) {
-  return blend < 0.5 ? blendLinearBurn(base, (2.0 * blend))
-                     : blendLinearDodge(base, (2.0 * (blend - 0.5)));
+  return blend < 0.5 ? blendLinearBurn(base, (2.0 * blend)) : blendLinearDodge(base, (2.0 * (blend - 0.5)));
 }
-
 vec3 blendLinearLight(vec3 base, vec3 blend) {
-  return vec3(blendLinearLight(base.r, blend.r),
-              blendLinearLight(base.g, blend.g),
-              blendLinearLight(base.b, blend.b));
+  return vec3(blendLinearLight(base.r, blend.r), blendLinearLight(base.g, blend.g), blendLinearLight(base.b, blend.b));
 }
-
-vec3 blendLinearLight(vec3 base, vec3 blend, float opacity) {
-  return (blendLinearLight(base, blend) * opacity + base * (1.0 - opacity));
-}
-
 float blendPinLight(float base, float blend) {
-  return (blend < 0.5) ? blendDarken(base, (2.0 * blend))
-                       : blendLighten(base, (2.0 * (blend - 0.5)));
+  return (blend < 0.5) ? blendDarken(base, (2.0 * blend)) : blendLighten(base, (2.0 * (blend - 0.5)));
 }
-
 vec3 blendPinLight(vec3 base, vec3 blend) {
-  return vec3(blendPinLight(base.r, blend.r), blendPinLight(base.g, blend.g),
-              blendPinLight(base.b, blend.b));
+  return vec3(blendPinLight(base.r, blend.r), blendPinLight(base.g, blend.g), blendPinLight(base.b, blend.b));
 }
 
-vec3 blendPinLight(vec3 base, vec3 blend, float opacity) {
-  return (blendPinLight(base, blend) * opacity + base * (1.0 - opacity));
-}
-
+// 3-argument version of blendMode
 vec3 blendMode(int mode, vec3 base, vec3 blend) {
-  if (mode == 1) {
-    return blendAdd(base, blend);
-  } else if (mode == 2) {
-    return blendAverage(base, blend);
-  } else if (mode == 3) {
-    return blendColorBurn(base, blend);
-  } else if (mode == 4) {
-    return blendColorDodge(base, blend);
-  } else if (mode == 5) {
-    return blendDarken(base, blend);
-  } else if (mode == 6) {
-    return blendDifference(base, blend);
-  } else if (mode == 7) {
-    return blendExclusion(base, blend);
-  } else if (mode == 8) {
-    return blendGlow(base, blend);
-  } else if (mode == 9) {
-    return blendHardLight(base, blend);
-  } else if (mode == 10) {
-    return blendHardMix(base, blend);
-  } else if (mode == 11) {
-    return blendLighten(base, blend);
-  } else if (mode == 12) {
-    return blendLinearBurn(base, blend);
-  } else if (mode == 13) {
-    return blendLinearDodge(base, blend);
-  } else if (mode == 14) {
-    return blendLinearLight(base, blend);
-  } else if (mode == 15) {
-    return blendMultiply(base, blend);
-  } else if (mode == 16) {
-    return blendNegation(base, blend);
-  } else if (mode == 17) {
-    return blendNormal(base, blend);
-  } else if (mode == 18) {
-    return blendOverlay(base, blend);
-  } else if (mode == 19) {
-    return blendPhoenix(base, blend);
-  } else if (mode == 20) {
-    return blendPinLight(base, blend);
-  } else if (mode == 21) {
-    return blendReflect(base, blend);
-  } else if (mode == 22) {
-    return blendScreen(base, blend);
-  } else if (mode == 23) {
-    return blendSoftLight(base, blend);
-  } else if (mode == 24) {
-    return blendSubtract(base, blend);
-  } else if (mode == 25) {
-    return blendVividLight(base, blend);
-  } else {
-    return vec3(0.,0.,0.);
-  }
+  if (mode == 1) return blendAdd(base, blend);
+  else if (mode == 2) return blendAverage(base, blend);
+  else if (mode == 3) return blendColorBurn(base, blend);
+  else if (mode == 4) return blendColorDodge(base, blend);
+  else if (mode == 5) return blendDarken(base, blend);
+  else if (mode == 6) return blendDifference(base, blend);
+  else if (mode == 7) return blendExclusion(base, blend);
+  else if (mode == 8) return blendGlow(base, blend);
+  else if (mode == 9) return blendHardLight(base, blend);
+  else if (mode == 10) return blendHardMix(base, blend);
+  else if (mode == 11) return blendLighten(base, blend);
+  else if (mode == 12) return blendLinearBurn(base, blend);
+  else if (mode == 13) return blendLinearDodge(base, blend);
+  else if (mode == 14) return blendLinearLight(base, blend);
+  else if (mode == 15) return blendMultiply(base, blend);
+  else if (mode == 16) return blendNegation(base, blend);
+  else if (mode == 17) return blendNormal(base, blend);
+  else if (mode == 18) return blendOverlay(base, blend);
+  else if (mode == 19) return blendPhoenix(base, blend);
+  else if (mode == 20) return blendPinLight(base, blend);
+  else if (mode == 21) return blendReflect(base, blend);
+  else if (mode == 22) return blendScreen(base, blend);
+  else if (mode == 23) return blendSoftLight(base, blend);
+  else if (mode == 24) return blendSubtract(base, blend);
+  else if (mode == 25) return blendVividLight(base, blend);
+  else return vec3(0.,0.,0.);
 }
 
+// 4-argument version (handles the opacity mapping beautifully with mix!)
 vec3 blendMode(int mode, vec3 base, vec3 blend, float opacity) {
-  if (mode == 1) {
-    return blendAdd(base, blend, opacity);
-  } else if (mode == 2) {
-    return blendAverage(base, blend, opacity);
-  } else if (mode == 3) {
-    return blendColorBurn(base, blend, opacity);
-  } else if (mode == 4) {
-    return blendColorDodge(base, blend, opacity);
-  } else if (mode == 5) {
-    return blendDarken(base, blend, opacity);
-  } else if (mode == 6) {
-    return blendDifference(base, blend, opacity);
-  } else if (mode == 7) {
-    return blendExclusion(base, blend, opacity);
-  } else if (mode == 8) {
-    return blendGlow(base, blend, opacity);
-  } else if (mode == 9) {
-    return blendHardLight(base, blend, opacity);
-  } else if (mode == 10) {
-    return blendHardMix(base, blend, opacity);
-  } else if (mode == 11) {
-    return blendLighten(base, blend, opacity);
-  } else if (mode == 12) {
-    return blendLinearBurn(base, blend, opacity);
-  } else if (mode == 13) {
-    return blendLinearDodge(base, blend, opacity);
-  } else if (mode == 14) {
-    return blendLinearLight(base, blend, opacity);
-  } else if (mode == 15) {
-    return blendMultiply(base, blend, opacity);
-  } else if (mode == 16) {
-    return blendNegation(base, blend, opacity);
-  } else if (mode == 17) {
-    return blendNormal(base, blend, opacity);
-  } else if (mode == 18) {
-    return blendOverlay(base, blend, opacity);
-  } else if (mode == 19) {
-    return blendPhoenix(base, blend, opacity);
-  } else if (mode == 20) {
-    return blendPinLight(base, blend, opacity);
-  } else if (mode == 21) {
-    return blendReflect(base, blend, opacity);
-  } else if (mode == 22) {
-    return blendScreen(base, blend, opacity);
-  } else if (mode == 23) {
-    return blendSoftLight(base, blend, opacity);
-  } else if (mode == 24) {
-    return blendSubtract(base, blend, opacity);
-  } else if (mode == 25) {
-    return blendVividLight(base, blend, opacity);
-  } else {
-    return vec3(0.,0.,0.);
-  }
+    return mix(base, blendMode(mode, base, blend), opacity);
 }
 
 void main() {
-  vec4 s1 = IMG_THIS_PIXEL(t1);
-  vec4 s2 = IMG_THIS_PIXEL(t2);
-  vec4 s3 = IMG_THIS_PIXEL(t3);
-  vec4 s4 = IMG_THIS_PIXEL(t4);
-  vec4 s5 = IMG_THIS_PIXEL(t5);
-  vec4 s6 = IMG_THIS_PIXEL(t6);
-  vec4 s7 = IMG_THIS_PIXEL(t7);
-  vec4 s8 = IMG_THIS_PIXEL(t8);
-
-  // Bottom-to-top compositing: t1 is the base, each layer blends on top
+  // Base Layer (t1)
+  vec4 s1 = vec4(0.0);
+  if (alpha1 > 0.0) {
+      s1 = IMG_THIS_PIXEL(t1);
+  }
   float a = s1.a * alpha1;
   vec3 rgb = s1.rgb * a;
-  float ea;
+  
+  // Layer 2
+  if (alpha2 > 0.0) {
+      vec4 s2 = IMG_THIS_PIXEL(t2);
+      float ea = s2.a * alpha2;
+      if (ea > 0.0) {
+          rgb = blendMode(mode1, rgb, s2.rgb, ea);
+          a = a + ea * (1.0 - a);
+      }
+  }
 
-  ea = s2.a * alpha2;
-  rgb = blendMode(mode1, rgb, s2.rgb, ea);
-  a = a + ea * (1.0 - a);
+  // Layer 3
+  if (alpha3 > 0.0) {
+      vec4 s3 = IMG_THIS_PIXEL(t3);
+      float ea = s3.a * alpha3;
+      if (ea > 0.0) {
+          rgb = blendMode(mode2, rgb, s3.rgb, ea);
+          a = a + ea * (1.0 - a);
+      }
+  }
 
-  ea = s3.a * alpha3;
-  rgb = blendMode(mode2, rgb, s3.rgb, ea);
-  a = a + ea * (1.0 - a);
+  // Layer 4
+  if (alpha4 > 0.0) {
+      vec4 s4 = IMG_THIS_PIXEL(t4);
+      float ea = s4.a * alpha4;
+      if (ea > 0.0) {
+          rgb = blendMode(mode3, rgb, s4.rgb, ea);
+          a = a + ea * (1.0 - a);
+      }
+  }
 
-  ea = s4.a * alpha4;
-  rgb = blendMode(mode3, rgb, s4.rgb, ea);
-  a = a + ea * (1.0 - a);
+  // Layer 5
+  if (alpha5 > 0.0) {
+      vec4 s5 = IMG_THIS_PIXEL(t5);
+      float ea = s5.a * alpha5;
+      if (ea > 0.0) {
+          rgb = blendMode(mode4, rgb, s5.rgb, ea);
+          a = a + ea * (1.0 - a);
+      }
+  }
 
-  ea = s5.a * alpha5;
-  rgb = blendMode(mode4, rgb, s5.rgb, ea);
-  a = a + ea * (1.0 - a);
+  // Layer 6
+  if (alpha6 > 0.0) {
+      vec4 s6 = IMG_THIS_PIXEL(t6);
+      float ea = s6.a * alpha6;
+      if (ea > 0.0) {
+          rgb = blendMode(mode5, rgb, s6.rgb, ea);
+          a = a + ea * (1.0 - a);
+      }
+  }
 
-  ea = s6.a * alpha6;
-  rgb = blendMode(mode5, rgb, s6.rgb, ea);
-  a = a + ea * (1.0 - a);
+  // Layer 7
+  if (alpha7 > 0.0) {
+      vec4 s7 = IMG_THIS_PIXEL(t7);
+      float ea = s7.a * alpha7;
+      if (ea > 0.0) {
+          rgb = blendMode(mode6, rgb, s7.rgb, ea);
+          a = a + ea * (1.0 - a);
+      }
+  }
 
-  ea = s7.a * alpha7;
-  rgb = blendMode(mode6, rgb, s7.rgb, ea);
-  a = a + ea * (1.0 - a);
-
-  ea = s8.a * alpha8;
-  rgb = blendMode(mode7, rgb, s8.rgb, ea);
-  a = a + ea * (1.0 - a);
+  // Layer 8
+  if (alpha8 > 0.0) {
+      vec4 s8 = IMG_THIS_PIXEL(t8);
+      float ea = s8.a * alpha8;
+      if (ea > 0.0) {
+          rgb = blendMode(mode7, rgb, s8.rgb, ea);
+          a = a + ea * (1.0 - a);
+      }
+  }
 
   gl_FragColor = vec4(rgb, a);
 }


### PR DESCRIPTION
Adding new dometool shaders:

- **domemaster_mask:** Applies a customizable Domemaster mask defined by a polar angle range, a color, and a feathered edge (softness). Assumes the input is a 210-degree FOV Domemaster projection.
- **hexagonal_faces_to_domemaster**: Hexagonal Prism Domemaster. 6 side faces (split into top/bottom halves, bottom rotated 180) + 2 pole faces. Preserves transparency.
- Video Mixer dome (a version of Video Mixer that enforces 1:1 aspect ratio)
- **half_cubesides_to_domemaster**: Optimized single-pass Domemaster to create a domaster from half-cube images. Maps raw 2:1 images to top/bottom halves, rotating the bottom 180. Includes API-level input flips.

Proposing an optimization for the Video Mixer: skip processing fully transparent images.

(This branch can be deleted after merge).