### PR TITLE
Presets: demonstration set for the Object filter

### DIFF
--- a/Presets/Object filter/Entity X coordinates.scp
+++ b/Presets/Object filter/Entity X coordinates.scp
@@ -1,1 +1,1 @@
-{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Entity X coordinates","Category":"Entities","Preset":[[0,{"String":"[ .[].position[0] ]"}]]}
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Entity X coordinates","Category":"Entities","Preset":[[1,{"String":"[ .[].position[0] ]"}]]}

--- a/Presets/Object filter/Entity X coordinates.scp
+++ b/Presets/Object filter/Entity X coordinates.scp
@@ -1,0 +1,1 @@
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Entity X coordinates","Category":"Entities","Preset":[[0,{"String":"[ .[].position[0] ]"}]]}

--- a/Presets/Object filter/Entity confidences.scp
+++ b/Presets/Object filter/Entity confidences.scp
@@ -1,0 +1,1 @@
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Entity confidences","Category":"Entities","Preset":[[0,{"String":"[ .[].confidence ]"}]]}

--- a/Presets/Object filter/Entity confidences.scp
+++ b/Presets/Object filter/Entity confidences.scp
@@ -1,1 +1,1 @@
-{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Entity confidences","Category":"Entities","Preset":[[0,{"String":"[ .[].confidence ]"}]]}
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Entity confidences","Category":"Entities","Preset":[[1,{"String":"[ .[].confidence ]"}]]}

--- a/Presets/Object filter/Entity ids.scp
+++ b/Presets/Object filter/Entity ids.scp
@@ -1,1 +1,1 @@
-{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Entity ids","Category":"Entities","Preset":[[0,{"String":"[ .[].id ]"}]]}
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Entity ids","Category":"Entities","Preset":[[1,{"String":"[ .[].id ]"}]]}

--- a/Presets/Object filter/Entity ids.scp
+++ b/Presets/Object filter/Entity ids.scp
@@ -1,0 +1,1 @@
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Entity ids","Category":"Entities","Preset":[[0,{"String":"[ .[].id ]"}]]}

--- a/Presets/Object filter/Entity positions.scp
+++ b/Presets/Object filter/Entity positions.scp
@@ -1,0 +1,1 @@
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Entity positions","Category":"Entities","Preset":[[0,{"String":"[ .[].position ]"}]]}

--- a/Presets/Object filter/Entity positions.scp
+++ b/Presets/Object filter/Entity positions.scp
@@ -1,1 +1,1 @@
-{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Entity positions","Category":"Entities","Preset":[[0,{"String":"[ .[].position ]"}]]}
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Entity positions","Category":"Entities","Preset":[[1,{"String":"[ .[].position ]"}]]}

--- a/Presets/Object filter/Field by name.scp
+++ b/Presets/Object filter/Field by name.scp
@@ -1,1 +1,1 @@
-{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Field by name","Category":"Nested","Preset":[[0,{"String":".position"}]]}
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Field by name","Category":"Nested","Preset":[[1,{"String":".position"}]]}

--- a/Presets/Object filter/Field by name.scp
+++ b/Presets/Object filter/Field by name.scp
@@ -1,0 +1,1 @@
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Field by name","Category":"Nested","Preset":[[0,{"String":".position"}]]}

--- a/Presets/Object filter/Find a field anywhere.scp
+++ b/Presets/Object filter/Find a field anywhere.scp
@@ -1,1 +1,1 @@
-{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Find a field anywhere","Category":"Nested","Preset":[[1,{"String":"[ .. | .confidence ]"}]]}
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Find a field anywhere","Category":"Nested","Preset":[[1,{"String":"[ .. | .confidence? ]"}]]}

--- a/Presets/Object filter/Find a field anywhere.scp
+++ b/Presets/Object filter/Find a field anywhere.scp
@@ -1,1 +1,1 @@
-{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Find a field anywhere","Category":"Nested","Preset":[[0,{"String":"[ .. | .confidence ]"}]]}
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Find a field anywhere","Category":"Nested","Preset":[[1,{"String":"[ .. | .confidence ]"}]]}

--- a/Presets/Object filter/Find a field anywhere.scp
+++ b/Presets/Object filter/Find a field anywhere.scp
@@ -1,0 +1,1 @@
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Find a field anywhere","Category":"Nested","Preset":[[0,{"String":"[ .. | .confidence ]"}]]}

--- a/Presets/Object filter/First and third.scp
+++ b/Presets/Object filter/First and third.scp
@@ -1,1 +1,1 @@
-{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"First and third","Category":"Selecting","Preset":[[0,{"String":"[ .[0,2] ]"}]]}
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"First and third","Category":"Selecting","Preset":[[1,{"String":"[ .[0,2] ]"}]]}

--- a/Presets/Object filter/First and third.scp
+++ b/Presets/Object filter/First and third.scp
@@ -1,0 +1,1 @@
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"First and third","Category":"Selecting","Preset":[[0,{"String":"[ .[0,2] ]"}]]}

--- a/Presets/Object filter/First four numbers.scp
+++ b/Presets/Object filter/First four numbers.scp
@@ -1,0 +1,1 @@
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"First four numbers","Category":"Numbers","Preset":[[0,{"String":".[0:4]"}]]}

--- a/Presets/Object filter/First four numbers.scp
+++ b/Presets/Object filter/First four numbers.scp
@@ -1,1 +1,1 @@
-{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"First four numbers","Category":"Numbers","Preset":[[0,{"String":".[0:4]"}]]}
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"First four numbers","Category":"Numbers","Preset":[[1,{"String":".[0:4]"}]]}

--- a/Presets/Object filter/First item.scp
+++ b/Presets/Object filter/First item.scp
@@ -1,0 +1,1 @@
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"First item","Category":"Basics","Preset":[[0,{"String":".[0]"}]]}

--- a/Presets/Object filter/First item.scp
+++ b/Presets/Object filter/First item.scp
@@ -1,1 +1,1 @@
-{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"First item","Category":"Basics","Preset":[[0,{"String":".[0]"}]]}
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"First item","Category":"Basics","Preset":[[1,{"String":".[0]"}]]}

--- a/Presets/Object filter/First two only.scp
+++ b/Presets/Object filter/First two only.scp
@@ -1,1 +1,1 @@
-{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"First two only","Category":"Selecting","Preset":[[0,{"String":".[0:2]"}]]}
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"First two only","Category":"Selecting","Preset":[[1,{"String":".[0:2]"}]]}

--- a/Presets/Object filter/First two only.scp
+++ b/Presets/Object filter/First two only.scp
@@ -1,0 +1,1 @@
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"First two only","Category":"Selecting","Preset":[[0,{"String":".[0:2]"}]]}

--- a/Presets/Object filter/Id and position only.scp
+++ b/Presets/Object filter/Id and position only.scp
@@ -1,0 +1,1 @@
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Id and position only","Category":"Entities","Preset":[[0,{"String":".[] | { id, position }"}]]}

--- a/Presets/Object filter/Id and position only.scp
+++ b/Presets/Object filter/Id and position only.scp
@@ -1,1 +1,1 @@
-{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Id and position only","Category":"Entities","Preset":[[0,{"String":".[] | { id, position }"}]]}
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Id and position only","Category":"Entities","Preset":[[1,{"String":".[] | { id, position }"}]]}

--- a/Presets/Object filter/Names from a list.scp
+++ b/Presets/Object filter/Names from a list.scp
@@ -1,0 +1,1 @@
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Names from a list","Category":"Nested","Preset":[[0,{"String":"[ .[].name ]"}]]}

--- a/Presets/Object filter/Names from a list.scp
+++ b/Presets/Object filter/Names from a list.scp
@@ -1,1 +1,1 @@
-{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Names from a list","Category":"Nested","Preset":[[0,{"String":"[ .[].name ]"}]]}
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Names from a list","Category":"Nested","Preset":[[1,{"String":"[ .[].name ]"}]]}

--- a/Presets/Object filter/One output per item.scp
+++ b/Presets/Object filter/One output per item.scp
@@ -1,1 +1,1 @@
-{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"One output per item","Category":"Basics","Preset":[[0,{"String":".[]"}]]}
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"One output per item","Category":"Basics","Preset":[[1,{"String":".[]"}]]}

--- a/Presets/Object filter/One output per item.scp
+++ b/Presets/Object filter/One output per item.scp
@@ -1,0 +1,1 @@
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"One output per item","Category":"Basics","Preset":[[0,{"String":".[]"}]]}

--- a/Presets/Object filter/Pass through.scp
+++ b/Presets/Object filter/Pass through.scp
@@ -1,0 +1,1 @@
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Pass through","Category":"Basics","Preset":[[0,{"String":"."}]]}

--- a/Presets/Object filter/Pass through.scp
+++ b/Presets/Object filter/Pass through.scp
@@ -1,1 +1,1 @@
-{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Pass through","Category":"Basics","Preset":[[0,{"String":"."}]]}
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Pass through","Category":"Basics","Preset":[[1,{"String":"."}]]}

--- a/Presets/Object filter/Position as x and y fields.scp
+++ b/Presets/Object filter/Position as x and y fields.scp
@@ -1,0 +1,1 @@
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Position as x and y fields","Category":"Entities","Preset":[[0,{"String":".[] | { id, x: .position[0], y: .position[1] }"}]]}

--- a/Presets/Object filter/Position as x and y fields.scp
+++ b/Presets/Object filter/Position as x and y fields.scp
@@ -1,1 +1,1 @@
-{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Position as x and y fields","Category":"Entities","Preset":[[0,{"String":".[] | { id, x: .position[0], y: .position[1] }"}]]}
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Position as x and y fields","Category":"Entities","Preset":[[1,{"String":".[] | { id, x: .position[0], y: .position[1] }"}]]}

--- a/Presets/Object filter/Rename for a receiver.scp
+++ b/Presets/Object filter/Rename for a receiver.scp
@@ -1,0 +1,1 @@
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Rename for a receiver","Category":"Entities","Preset":[[0,{"String":".[] | { who: .id, where: .position }"}]]}

--- a/Presets/Object filter/Rename for a receiver.scp
+++ b/Presets/Object filter/Rename for a receiver.scp
@@ -1,1 +1,1 @@
-{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Rename for a receiver","Category":"Entities","Preset":[[0,{"String":".[] | { who: .id, where: .position }"}]]}
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Rename for a receiver","Category":"Entities","Preset":[[1,{"String":".[] | { who: .id, where: .position }"}]]}

--- a/Presets/Object filter/Skip the first.scp
+++ b/Presets/Object filter/Skip the first.scp
@@ -1,1 +1,1 @@
-{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Skip the first","Category":"Selecting","Preset":[[0,{"String":".[1:8]"}]]}
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Skip the first","Category":"Selecting","Preset":[[1,{"String":".[1:8]"}]]}

--- a/Presets/Object filter/Skip the first.scp
+++ b/Presets/Object filter/Skip the first.scp
@@ -1,0 +1,1 @@
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Skip the first","Category":"Selecting","Preset":[[0,{"String":".[1:8]"}]]}

--- a/Presets/Object filter/Split into pairs.scp
+++ b/Presets/Object filter/Split into pairs.scp
@@ -1,0 +1,1 @@
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Split into pairs","Category":"Numbers","Preset":[[0,{"String":"[ .[0:2] , .[2:4] ]"}]]}

--- a/Presets/Object filter/Split into pairs.scp
+++ b/Presets/Object filter/Split into pairs.scp
@@ -1,1 +1,1 @@
-{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Split into pairs","Category":"Numbers","Preset":[[0,{"String":"[ .[0:2] , .[2:4] ]"}]]}
+{"Key":{"Uuid":"4cf2f89f-45b6-4878-92ff-23d3cee1c67e","Effect":""},"Name":"Split into pairs","Category":"Numbers","Preset":[[1,{"String":"[ .[0:2] , .[2:4] ]"}]]}


### PR DESCRIPTION
18 presets for the jq-subset Object filter, grouped so the list reads as a short tutorial rather than a pile of expressions: **Basics**, **Entities**, **Selecting**, **Nested**, **Numbers**.

Written around the data score actually carries. The Entities group works on a Point Tracker `Tracks` frame — a list of per-entity maps with `id`, `position`, `confidence`, `state` — which is the shape most worth thinning before it reaches a renderer or a MIDI mapping:

```
[ .[].id ]
.[] | { id, x: .position[0], y: .position[1] }
.[] | { who: .id, where: .position }
```

**Numbers** covers the flat frames a blob tracker, an OSC bundle or a sensor sends; **Nested** covers device replies and JSON arriving over a websocket, including `[ .. | .confidence ]` for reaching a field at unknown depth.

### Every program was run before it was written down

Which is also how the edges of the implemented subset got mapped:

- **`.[-1]` parses but yields nothing.** Negative indexing is accepted by the grammar and silently produces no output, so nothing here uses one — "the last one" is spelled as a slice.
- **A slice already produces a list**, so `[ .[0:2] ]` nests one level deeper than intended; the bare form is what a caller wants.
- **`.[] | .a, .b` does not interleave** the two fields.

None of these are errors at the parser level. The object simply stays quiet or emits the wrong shape, which from the outside is indistinguishable from a patching mistake — exactly what a demonstration set should steer people away from.

One more trap worth knowing, found while validating: pointing an entity program at a numeric frame emits **one empty object per number** rather than nothing, so it looks like it is working. The validation checks each preset against the shape its category names and rejects all-empty-object output as degenerate.

Split out of #23, which merged before these were pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnNVzm2dPA5iHbSYKrpzZj