### PR TITLE
Add a Canvas2D painter with a compact persistent editor

### DIFF
--- a/Presets/Javascript/canvas-painter/PaintModel.js
+++ b/Presets/Javascript/canvas-painter/PaintModel.js
@@ -1,0 +1,79 @@
+.pragma library
+
+function defaultPalette() {
+    return ["#ededed", "#171717", "#e85858", "#e59f38", "#f0da68", "#82c75a", "#42b99c", "#4eade3", "#6276de", "#af74d2", "#e484b6", "#87593e"];
+}
+function palette(colors) {
+    var result = defaultPalette();
+    if (Array.isArray(colors)) {
+        for (var i = 0; i < result.length; ++i) {
+            if (typeof colors[i] === "string" && /^#([0-9a-f]{6}|[0-9a-f]{8})$/i.test(colors[i]))
+                result[i] = colors[i].toLowerCase();
+        }
+    }
+    return result;
+}
+function defaults() {
+    return {
+        version: 1,
+        width: 1280,
+        height: 720,
+        background: "#00000000",
+        config: {
+            tool: "brush",
+            color: "#ffededed",
+            width: 12,
+            opacity: 1,
+            feather: 0,
+            filled: false
+        },
+        palette: defaultPalette(),
+        strokes: []
+    };
+}
+function number(value, fallback, min, max) {
+    value = Number(value);
+    return isFinite(value) ? Math.max(min, Math.min(max, value)) : fallback;
+}
+function parse(value) {
+    var d = typeof value === "string" ? JSON.parse(value) : value;
+    if (!d || d.version !== 1 || !Array.isArray(d.strokes))
+        throw new Error("Unsupported paint document");
+    var config = d.config || {};
+    var tools = ["brush", "eraser", "line", "rectangle", "ellipse", "eyedropper"];
+    return {
+        version: 1,
+        width: 1280,
+        height: 720,
+        background: d.background || "#00000000",
+        config: {
+            tool: tools.indexOf(config.tool) >= 0 ? config.tool : "brush",
+            color: config.color || "#ffededed",
+            width: number(config.width, 12, 1, 200),
+            opacity: number(config.opacity, 1, 0, 1),
+            feather: number(config.feather, 0, 0, 1),
+            filled: !!config.filled
+        },
+        palette: palette(d.palette),
+        strokes: d.strokes
+    };
+}
+function append(doc, command) {
+    doc.strokes.push(command);
+}
+function pickColor(doc, color) {
+    doc.config.color = color.toString();
+    // The sampled alpha already includes paint opacity; do not apply it twice.
+    doc.config.opacity = 1;
+    doc.config.tool = "brush";
+}
+function clearCommand() {
+    return {
+        tool: "clear",
+        color: "#ffffffff",
+        width: 1,
+        opacity: 1,
+        filled: false,
+        points: [[0, 0]]
+    };
+}

--- a/Presets/Javascript/canvas-painter/PaintSurface.qml
+++ b/Presets/Javascript/canvas-painter/PaintSurface.qml
@@ -1,0 +1,336 @@
+import QtQuick
+import QtCanvas2D
+
+Item {
+    id: root
+    property color fillColor: "transparent"
+    signal colorSampled(color color)
+    clip: true
+
+    property var _commands: []
+    property var _active: null
+    property var _removedGroups: []
+    property int _sampleGeneration: 0
+    property var _pendingSample: null
+
+    onFillColorChanged: cancelSample()
+    onWidthChanged: cancelSample()
+    onHeightChanged: cancelSample()
+
+    function bounded(value, fallback, low, high) {
+        value = Number(value);
+        return isFinite(value) ? Math.max(low, Math.min(high, value)) : fallback;
+    }
+    function point(x, y) {
+        return [bounded(x, 0, 0, 1280), bounded(y, 0, 0, 720)];
+    }
+    function samePoint(a, b) {
+        return a[0] === b[0] && a[1] === b[1];
+    }
+    function hexByte(value) {
+        return ("0" + Math.round(value * 255).toString(16)).slice(-2);
+    }
+    function style(config) {
+        config = config || {};
+        var tool = config.tool;
+        if (tool !== "eraser" && tool !== "line" && tool !== "rectangle" && tool !== "ellipse" && tool !== "clear")
+            tool = "brush";
+        var color;
+        try {
+            color = Qt.color(config.color === undefined ? "#ededed" : String(config.color));
+        } catch (error) {
+            color = Qt.rgba(1, 1, 1, 1);
+        }
+        if (!color || !color.valid)
+            color = Qt.rgba(1, 1, 1, 1);
+        return {
+            tool: tool,
+            color: "#" + hexByte(color.a) + hexByte(color.r) + hexByte(color.g) + hexByte(color.b),
+            width: bounded(config.width === undefined ? 8 : config.width, 8, 1, 200),
+            opacity: bounded(config.opacity === undefined ? 1 : config.opacity, 1, 0, 1),
+            feather: bounded(config.feather === undefined ? 0 : config.feather, 0, 0, 1),
+            filled: !!config.filled,
+            points: []
+        };
+    }
+    function retained(command, group, key) {
+        return {
+            command: command,
+            key: key,
+            group: group,
+            path: null,
+            pointCount: 0,
+            dirty: true,
+            featherLayers: null
+        };
+    }
+    function loadCommands(commands) {
+        cancelSample();
+        _active = null;
+        commands = commands || [];
+        var next = [];
+        var common = true;
+        for (var i = 0; i < commands.length; ++i) {
+            var source = commands[i] || {};
+            var command = style(source);
+            var points = source.points || [];
+            for (var j = 0; j < points.length; ++j) {
+                var xy = points[j];
+                if (xy && xy.length === 2)
+                    command.points.push(point(xy[0], xy[1]));
+            }
+            var key = JSON.stringify(command);
+            if (common && i < _commands.length && _commands[i].key === key) {
+                next.push(_commands[i]);
+            } else {
+                common = false;
+                if (i < _commands.length)
+                    _removedGroups.push(i);
+                next.push(retained(command, i, key));
+            }
+        }
+        for (var k = commands.length; k < _commands.length; ++k)
+            _removedGroups.push(k);
+        _commands = next;
+        ink.requestPaint();
+    }
+    function beginStroke(config, x, y) {
+        cancelSample();
+        var command = style(config);
+        command.points.push(point(x, y));
+        // Live paths have no GPU cache group; committed paths retain their geometry.
+        _active = retained(command, -1);
+        ink.requestPaint();
+    }
+    function extendStroke(x, y) {
+        if (!_active)
+            return;
+        var points = _active.command.points;
+        var p = point(x, y);
+        if (samePoint(p, points[points.length - 1]))
+            return;
+        cancelSample();
+        var tool = _active.command.tool;
+        if (tool === "brush" || tool === "eraser" || points.length === 1)
+            points.push(p);
+        else
+            points[points.length - 1] = p;
+        _active.dirty = true;
+        ink.requestPaint();
+    }
+    function endStroke() {
+        if (!_active)
+            return {};
+        cancelSample();
+        _active.group = _commands.length;
+        _active.key = JSON.stringify(_active.command);
+        // Callers own the returned document data, not the retained render model.
+        var result = JSON.parse(_active.key);
+        _commands.push(_active);
+        _active = null;
+        ink.requestPaint();
+        return result;
+    }
+    function cancelStroke() {
+        cancelSample();
+        if (!_active)
+            return;
+        _active = null;
+        ink.requestPaint();
+    }
+    function cancelSample() {
+        ++_sampleGeneration;
+        _pendingSample = null;
+    }
+    function sampleColor(x, y) {
+        cancelSample();
+        _pendingSample = {
+            point: point(x, y),
+            generation: _sampleGeneration
+        };
+        // The paint handler schedules the grab only after recording the latest ink.
+        ink.requestPaint();
+    }
+    function grabSample() {
+        var sample = _pendingSample;
+        if (!sample || !ink.available || width <= 0 || height <= 0)
+            return;
+        // grabToImage's targetSize is logical: Qt multiplies it by the window DPR.
+        // The fixed document-sized Canvas2D uses exactly the same physical size.
+        var pixels = ink.effectiveColorBufferSize;
+        if (pixels.width <= 0 || pixels.height <= 0)
+            return;
+        _pendingSample = null;
+        var x = Math.min(pixels.width - 1, Math.floor(sample.point[0] * pixels.width / 1280));
+        var y = Math.min(pixels.height - 1, Math.floor(sample.point[1] * pixels.height / 720));
+        // Record a full frame for the grab as well: Canvas2D is not an accumulating canvas.
+        ink.requestPaint();
+        root.grabToImage(function (result) {
+            if (sample.generation !== root._sampleGeneration)
+                return;
+            root.colorSampled(Util.imagePixelColor(result.image, x, y));
+        }, Qt.size(1280, 720));
+    }
+    function isDot(points) {
+        return points.length === 1 || (points.length === 2 && samePoint(points[0], points[1]));
+    }
+    function updatePath(ctx, entry) {
+        if (!entry.dirty)
+            return;
+        var command = entry.command;
+        var points = command.points;
+        if (!entry.path)
+            entry.path = ctx.createPath2D();
+        var path = entry.path;
+        var freehand = command.tool === "brush" || command.tool === "eraser";
+        // After the initial disk becomes a polyline, append only new segments.
+        if (freehand && entry.pointCount >= 2 && !isDot(points)) {
+            for (var i = entry.pointCount; i < points.length; ++i)
+                path.lineTo(points[i][0], points[i][1]);
+        } else {
+            path.clear();
+            if (points.length) {
+                var first = points[0];
+                var last = points[points.length - 1];
+                if (isDot(points)) {
+                    path.circle(first[0], first[1], command.width / 2);
+                } else if (command.tool === "rectangle" || command.tool === "ellipse") {
+                    var x = Math.min(first[0], last[0]);
+                    var y = Math.min(first[1], last[1]);
+                    var w = Math.abs(last[0] - first[0]);
+                    var h = Math.abs(last[1] - first[1]);
+                    if (command.tool === "rectangle")
+                        path.rect(x, y, w, h);
+                    else
+                        path.ellipseRect(x, y, w, h);
+                } else {
+                    path.moveTo(first[0], first[1]);
+                    for (var j = 1; j < points.length; ++j)
+                        path.lineTo(points[j][0], points[j][1]);
+                }
+            }
+        }
+        entry.pointCount = points.length;
+        entry.dirty = false;
+    }
+    function drawFeatheredBrush(ctx, entry) {
+        var command = entry.command;
+        if (!entry.featherLayers) {
+            var color = Qt.color(command.color);
+            var alpha = command.opacity * color.a;
+            entry.featherColor = Qt.rgba(color.r, color.g, color.b, 1);
+            entry.featherLayers = [];
+            // Canvas2D's antialias is capped at 10 pixels and extends outwards.
+            // Instead approximate a linear inward coverage ramp with nested paths.
+            // Midpoint radii keep the soft edge inside the nominal brush width.
+            var count = Math.max(1, Math.min(32, Math.ceil(command.width * command.feather / 2)));
+            for (var i = 0; i < count; ++i) {
+                entry.featherLayers.push({
+                    width: command.width * (1 - command.feather * (i + 0.5) / count),
+                    // Source-over must add alpha/count, not compound stroke opacity.
+                    alpha: (alpha / count) / (1 - alpha * i / count),
+                    path: null
+                });
+            }
+        }
+        ctx.strokeStyle = entry.featherColor;
+        ctx.fillStyle = entry.featherColor;
+        // Stencil each whole polyline once per layer, including self-intersections.
+        // Sampling a gesture more often must not deposit extra translucent dabs.
+        ctx.highQualityStroking = true;
+        var dot = isDot(command.points);
+        for (var j = 0; j < entry.featherLayers.length; ++j) {
+            var layer = entry.featherLayers[j];
+            ctx.globalAlpha = layer.alpha;
+            if (dot) {
+                if (!layer.path) {
+                    layer.path = ctx.createPath2D();
+                    layer.path.circle(command.points[0][0], command.points[0][1], layer.width / 2);
+                }
+                ctx.fill(layer.path, entry.group);
+            } else {
+                ctx.lineWidth = layer.width;
+                // Native cache keys include stroke width: all layers share one path.
+                ctx.stroke(entry.path, entry.group);
+            }
+        }
+        ctx.highQualityStroking = false;
+    }
+    function drawCommand(ctx, entry) {
+        var command = entry.command;
+        if (command.tool === "clear") {
+            ctx.globalAlpha = 1;
+            ctx.globalCompositeOperation = "source-over";
+            ctx.clearRect(0, 0, 1280, 720);
+            return;
+        }
+        if (!command.points.length)
+            return;
+        updatePath(ctx, entry);
+        ctx.globalCompositeOperation = command.tool === "eraser" ? "destination-out" : "source-over";
+        if (command.tool === "brush" && command.feather > 0) {
+            drawFeatheredBrush(ctx, entry);
+            return;
+        }
+        ctx.globalAlpha = command.opacity;
+        ctx.strokeStyle = command.tool === "eraser" ? "white" : command.color;
+        ctx.fillStyle = command.tool === "eraser" ? "white" : command.color;
+        ctx.lineWidth = command.width;
+        if (isDot(command.points) || (command.filled && (command.tool === "rectangle" || command.tool === "ellipse")))
+            ctx.fill(entry.path, entry.group);
+        else
+            ctx.stroke(entry.path, entry.group);
+    }
+
+    // Background is not paint: erasing/clearing ink always reveals the current color.
+    // The checkerboard lives outside this Item and is never included in a color grab.
+    Rectangle {
+        anchors.fill: parent
+        color: root.fillColor
+    }
+    Canvas2D {
+        id: ink
+        width: 1280
+        height: 720
+        transform: Scale {
+            xScale: root.width / 1280
+            yScale: root.height / 720
+        }
+        fillColor: "transparent"
+        alphaBlending: true
+        antialiasing: true
+        contextType: "2d"
+        onAvailableChanged: {
+            if (available)
+                requestPaint();
+            else
+                root.cancelSample();
+        }
+        onEffectiveColorBufferSizeChanged: {
+            // A queued sample can use the new size; an already-started grab cannot.
+            if (root._pendingSample)
+                requestPaint();
+            else
+                root.cancelSample();
+        }
+        onPaint: {
+            var ctx = getContext("2d");
+            if (!ctx)
+                return;
+            ctx.reset();
+            for (var i = 0; i < root._removedGroups.length; ++i)
+                ctx.removePathGroup(root._removedGroups[i]);
+            root._removedGroups = [];
+            ctx.lineCap = "round";
+            ctx.lineJoin = "round";
+            // Upstream clears the render target before each paint. Replay retained paths
+            // plus exactly one live stroke, so opacity, cancel, and erasers never accumulate.
+            for (var j = 0; j < root._commands.length; ++j)
+                root.drawCommand(ctx, root._commands[j]);
+            if (root._active)
+                root.drawCommand(ctx, root._active);
+            if (root._pendingSample)
+                Qt.callLater(root.grabSample);
+        }
+    }
+}

--- a/Presets/Javascript/canvas-painter/PaintView.qml
+++ b/Presets/Javascript/canvas-painter/PaintView.qml
@@ -1,0 +1,157 @@
+import QtQuick
+
+Item {
+    id: root
+    property var config: ({
+            tool: "brush",
+            color: "#ffededed",
+            width: 12,
+            opacity: 1,
+            filled: false
+        })
+    property color backgroundColor: "transparent"
+    property bool checkerboard: false
+    property bool interactive: true
+    property bool remoteDrawing: false
+    property bool sampling: false
+    onConfigChanged: {
+        sampling = false;
+        if (painter)
+            painter.cancelSample();
+    }
+    onBackgroundColorChanged: {
+        sampling = false;
+        if (painter)
+            painter.cancelSample();
+    }
+    readonly property bool drawing: pointer.pressed || remoteDrawing
+    signal gesture(var event)
+    signal committed(var command)
+    signal sampled(color color)
+
+    function load(doc) {
+        sampling = false;
+        remoteDrawing = false;
+        pointer.localStroke = false;
+        painter.loadCommands(doc.strokes);
+    }
+    function receive(event) {
+        if (!event)
+            return;
+        if (event.action === "begin") {
+            pointer.localStroke = false;
+            remoteDrawing = true;
+            painter.beginStroke(event.config, event.x, event.y);
+        } else if (event.action === "move" && remoteDrawing) {
+            painter.extendStroke(event.x, event.y);
+        } else if (event.action === "end" && remoteDrawing) {
+            painter.extendStroke(event.x, event.y);
+            painter.endStroke();
+            remoteDrawing = false;
+        } else if (event.action === "cancel") {
+            painter.cancelStroke();
+            remoteDrawing = false;
+        }
+    }
+    Item {
+        id: artboard
+        width: Math.min(root.width, root.height * 1280 / 720)
+        height: width * 720 / 1280
+        anchors.centerIn: parent
+        clip: true
+        Rectangle {
+            anchors.fill: parent
+            color: "#363a38"
+            visible: root.checkerboard
+        }
+        Repeater {
+            model: root.checkerboard ? 20 * 12 : 0
+            Rectangle {
+                required property int index
+                width: artboard.width / 20
+                height: artboard.height / 12
+                x: (index % 20) * width
+                y: Math.floor(index / 20) * height
+                color: ((index % 20) + Math.floor(index / 20)) % 2 ? "#454b47" : "#363a38"
+            }
+        }
+        PaintSurface {
+            id: painter
+            anchors.fill: parent
+            fillColor: root.backgroundColor
+            onColorSampled: function (color) {
+                if (!root.sampling || root.config.tool !== "eyedropper")
+                    return;
+                root.sampling = false;
+                root.sampled(color);
+            }
+        }
+        MouseArea {
+            id: pointer
+            anchors.fill: parent
+            enabled: root.interactive
+            acceptedButtons: Qt.LeftButton
+            hoverEnabled: true
+            preventStealing: true
+            cursorShape: root.config.tool === "eyedropper" ? Qt.PointingHandCursor : Qt.CrossCursor
+            property bool localStroke: false
+            function px(value) {
+                return Math.max(0, Math.min(1280, value * 1280 / width));
+            }
+            function py(value) {
+                return Math.max(0, Math.min(720, value * 720 / height));
+            }
+            onPressed: function (mouse) {
+                if (root.remoteDrawing) {
+                    mouse.accepted = false;
+                    return;
+                }
+                forceActiveFocus(Qt.MouseFocusReason);
+                if (root.config.tool === "eyedropper") {
+                    root.sampling = true;
+                    painter.sampleColor(px(mouse.x), py(mouse.y));
+                    return;
+                }
+                localStroke = true;
+                painter.beginStroke(root.config, px(mouse.x), py(mouse.y));
+                root.gesture({
+                    action: "begin",
+                    config: root.config,
+                    x: px(mouse.x),
+                    y: py(mouse.y)
+                });
+            }
+            onPositionChanged: function (mouse) {
+                if (!pressed || !localStroke)
+                    return;
+                painter.extendStroke(px(mouse.x), py(mouse.y));
+                root.gesture({
+                    action: "move",
+                    x: px(mouse.x),
+                    y: py(mouse.y)
+                });
+            }
+            onReleased: function (mouse) {
+                if (!localStroke)
+                    return;
+                painter.extendStroke(px(mouse.x), py(mouse.y));
+                root.gesture({
+                    action: "end",
+                    x: px(mouse.x),
+                    y: py(mouse.y)
+                });
+                localStroke = false;
+                root.committed(painter.endStroke());
+            }
+            onCanceled: {
+                if (!localStroke)
+                    return;
+                localStroke = false;
+                painter.cancelStroke();
+                root.gesture({
+                    action: "cancel"
+                });
+            }
+        }
+    }
+}

--- a/Presets/Javascript/canvas-painter/canvas-painter.qml
+++ b/Presets/Javascript/canvas-painter/canvas-painter.qml
@@ -1,0 +1,94 @@
+import Score
+import QtQuick
+import "PaintModel.js" as Model
+
+Script {
+    id: root
+    property var doc: Model.defaults()
+    property int revision: 0
+    property string serialized: ""
+    property var pendingCommits: []
+
+    function apply(value) {
+        if (value === serialized)
+            return;
+        try {
+            doc = value ? Model.parse(value) : Model.defaults();
+            serialized = value || JSON.stringify(doc);
+            revision++;
+            output.load(doc);
+        } catch (error) {
+            console.error("canvas-painter: " + error);
+        }
+    }
+    function commit() {
+        serialized = JSON.stringify(doc);
+        revision++;
+        // Process-lifetime transport commits on the GUI command stack. This is
+        // independent of ScriptUI lifetime, including when the editor is closed.
+        pendingCommits.push(serialized);
+        root.commitState("paintDoc", serialized);
+        root.uiSend({
+            type: "document",
+            doc: serialized
+        });
+    }
+    loadState: function (state) {
+        apply(state && state.paintDoc);
+    }
+    stateUpdated: function (key, value) {
+        if (key !== "paintDoc")
+            return;
+        var pending = pendingCommits.indexOf(value);
+        if (pending >= 0) {
+            pendingCommits.splice(pending, 1);
+            return;
+        }
+        apply(value);
+    }
+    uiEvent: function (message) {
+        if (!message)
+            return;
+        if (message.type === "document")
+            apply(message.doc);
+        else if (message.type === "gesture")
+            output.receive(message.event);
+        else if (message.type === "config") {
+            doc.config = message.config;
+            revision++;
+        } else if (message.type === "hello")
+            root.uiSend({
+                type: "document",
+                doc: JSON.stringify(doc)
+            });
+    }
+    TextureOutlet {
+        objectName: "Output"
+        item: PaintView {
+            id: output
+            anchors.fill: parent
+            config: {
+                root.revision;
+                return root.doc.config;
+            }
+            backgroundColor: {
+                root.revision;
+                return root.doc.background;
+            }
+            onGesture: function (event) {
+                root.uiSend({
+                    type: "gesture",
+                    event: event
+                });
+            }
+            onCommitted: function (command) {
+                Model.append(root.doc, command);
+                root.commit();
+            }
+            onSampled: function (color) {
+                Model.pickColor(root.doc, color);
+                root.commit();
+            }
+        }
+    }
+}

--- a/Presets/Javascript/canvas-painter/canvas-painter.qmlproject
+++ b/Presets/Javascript/canvas-painter/canvas-painter.qmlproject
@@ -1,0 +1,8 @@
+import QmlProject 1.3
+
+Project {
+    mainFile: "canvas-painter.qml"
+    QmlFiles { directory: "." }
+    JavaScriptFiles { directory: "." }
+    importPaths: [".", "../../../Scripts/include"]
+}

--- a/Presets/Javascript/canvas-painter/canvas-painter.ui.qml
+++ b/Presets/Javascript/canvas-painter/canvas-painter.ui.qml
@@ -1,0 +1,565 @@
+import Score
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import OssiaUI as S
+import "PaintModel.js" as Model
+
+ScriptUI {
+    id: root
+    anchors.fill: parent
+    implicitWidth: 1200
+    implicitHeight: 800
+    property var doc: Model.defaults()
+    property int revision: 0
+    property string serialized: ""
+    property var pendingCommits: []
+    property string status: ""
+    property bool alive: true
+    Component.onDestruction: alive = false
+    readonly property var config: {
+        revision;
+        return {
+            tool: doc.config.tool,
+            color: doc.config.color,
+            width: doc.config.width,
+            opacity: doc.config.opacity,
+            filled: doc.config.filled,
+            feather: doc.config.feather
+        };
+    }
+
+    function apply(value) {
+        if (value === serialized)
+            return;
+        try {
+            doc = value ? Model.parse(value) : Model.defaults();
+            serialized = value || JSON.stringify(doc);
+            revision++;
+            view.load(doc);
+            status = "";
+        } catch (error) {
+            status = "Cannot load paint document: " + error;
+        }
+    }
+    function sendLive() {
+        root.executionSend({
+            type: "document",
+            doc: serialized
+        });
+    }
+    function commit(label, reload) {
+        serialized = JSON.stringify(doc);
+        revision++;
+        if (reload)
+            view.load(doc);
+        pendingCommits.push(serialized);
+        root.beginUpdateState(label);
+        root.updateState("paintDoc", serialized);
+        root.endUpdateState();
+        sendLive();
+    }
+    function setConfig(key, value) {
+        if (config[key] === value || view.drawing)
+            return;
+        doc.config[key] = value;
+        commit("Change paint " + key, false);
+    }
+    function previewConfig(key, value) {
+        doc.config[key] = value;
+        revision++;
+        root.executionSend({
+            type: "config",
+            config: doc.config
+        });
+    }
+    function setTool(tool, filled) {
+        if (view.drawing)
+            return;
+        var shape = tool === "rectangle" || tool === "ellipse";
+        if (config.tool === tool && (!shape || config.filled === filled))
+            return;
+        doc.config.tool = tool;
+        if (shape)
+            doc.config.filled = filled;
+        commit("Change paint tool", false);
+    }
+    function setPaletteColor(index, color) {
+        if (view.drawing || index < 0 || index >= doc.palette.length || !color)
+            return;
+        var value = color.toString();
+        if (doc.palette[index] === value)
+            return;
+        doc.palette[index] = value;
+        commit("Change paint palette", false);
+    }
+    function chooseColor(slot) {
+        if (view.drawing)
+            return;
+        var originalDoc = doc;
+        var originalRevision = revision;
+        var initial = slot >= 0 ? doc.palette[slot] : slot === -2 ? doc.background : config.color;
+        var title = slot >= 0 ? "Palette color" : slot === -2 ? "Background color" : "Foreground color";
+        Util.openColorDialog(title, initial, function (color) {
+            if (!root || !root.alive || !color || view.drawing || root.doc !== originalDoc || root.revision !== originalRevision)
+                return;
+            if (slot >= 0)
+                root.setPaletteColor(slot, color);
+            else if (slot === -2)
+                root.setBackground(color);
+            else
+                root.setConfig("color", color.toString());
+        });
+    }
+    function setBackground(color) {
+        if (view.drawing || doc.background === color.toString())
+            return;
+        doc.background = color.toString();
+        commit("Change paint background", false);
+    }
+    loadState: function (state) {
+        apply(state && state.paintDoc);
+    }
+    stateUpdated: function (key, value) {
+        if (key !== "paintDoc")
+            return;
+        var pending = pendingCommits.indexOf(value);
+        if (pending >= 0) {
+            pendingCommits.splice(pending, 1);
+            return;
+        }
+        apply(value);
+    }
+    executionEvent: function (message) {
+        if (!message)
+            return;
+        if (message.type === "gesture")
+            view.receive(message.event);
+        else
+        // Runtime already submitted its own undoable process-state command.
+        // Reflect it here, but never submit a duplicate editor transaction.
+        if (message.type === "document")
+            apply(message.doc);
+    }
+    Timer {
+        interval: 0
+        running: true
+        onTriggered: root.executionSend({
+            type: "hello"
+        })
+    }
+
+    S.ThemedPage {
+        anchors.fill: parent
+        ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: 8
+            spacing: 8
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                spacing: 8
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    color: S.Theme.dark
+                    border.color: S.Theme.border
+                    ColumnLayout {
+                        anchors.fill: parent
+                        anchors.margins: 10
+                        spacing: 8
+                        PaintView {
+                            id: view
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            checkerboard: true
+                            config: root.config
+                            backgroundColor: {
+                                root.revision;
+                                return root.doc.background;
+                            }
+                            onGesture: function (event) {
+                                root.executionSend({
+                                    type: "gesture",
+                                    event: event
+                                });
+                            }
+                            onCommitted: function (command) {
+                                Model.append(root.doc, command);
+                                root.commit("Paint " + command.tool, false);
+                            }
+                            onSampled: function (color) {
+                                Model.pickColor(root.doc, color);
+                                root.commit("Pick paint color", false);
+                            }
+                        }
+                    }
+                }
+                Rectangle {
+                    Layout.preferredWidth: 256
+                    Layout.fillHeight: true
+                    color: S.Theme.base
+                    border.color: S.Theme.border
+                    ScrollView {
+                        anchors.fill: parent
+                        anchors.margins: 12
+                        contentWidth: availableWidth
+                        clip: true
+                        ColumnLayout {
+                            width: parent.width
+                            spacing: 10
+                            RowLayout {
+                                Layout.fillWidth: true
+                                S.SLabel {
+                                    text: "Tools"
+                                    font.bold: true
+                                    dim: true
+                                    Layout.fillWidth: true
+                                }
+                                S.SButton {
+                                    text: "Clear"
+                                    danger: true
+                                    enabled: {
+                                        root.revision;
+                                        return root.doc.strokes.length > 0 && !view.drawing;
+                                    }
+                                    tip: "Clear all paint, keeping the background. Undo restores it."
+                                    onClicked: {
+                                        Model.append(root.doc, Model.clearCommand());
+                                        root.commit("Clear paint", true);
+                                    }
+                                }
+                            }
+                            GridLayout {
+                                columns: 2
+                                Layout.fillWidth: true
+                                rowSpacing: 5
+                                columnSpacing: 5
+                                Repeater {
+                                    model: [
+                                        {
+                                            key: "brush",
+                                            label: "Brush",
+                                            tip: "Freehand stroke, with round caps"
+                                        },
+                                        {
+                                            key: "eraser",
+                                            label: "Eraser",
+                                            tip: "Erase paint to reveal the background or transparency without changing the background"
+                                        },
+                                        {
+                                            key: "line",
+                                            label: "Line",
+                                            tip: "Drag a straight line"
+                                        },
+                                        {
+                                            key: "eyedropper",
+                                            label: "Eyedropper",
+                                            tip: "Pick the rendered color, including opacity"
+                                        },
+                                        {
+                                            key: "rectangle",
+                                            label: "Outline",
+                                            filled: false,
+                                            tip: "Rectangle outline: drag from one corner to the opposite"
+                                        },
+                                        {
+                                            key: "rectangle",
+                                            label: "Filled",
+                                            filled: true,
+                                            tip: "Filled rectangle: drag from one corner to the opposite"
+                                        },
+                                        {
+                                            key: "ellipse",
+                                            label: "Outline",
+                                            filled: false,
+                                            tip: "Ellipse outline: drag its bounding box"
+                                        },
+                                        {
+                                            key: "ellipse",
+                                            label: "Filled",
+                                            filled: true,
+                                            tip: "Filled ellipse: drag its bounding box"
+                                        }
+                                    ]
+                                    S.SButton {
+                                        id: toolButton
+                                        required property var modelData
+                                        Layout.fillWidth: true
+                                        implicitHeight: 30
+                                        text: modelData.label
+                                        tip: modelData.tip
+                                        readonly property bool shape: modelData.key === "rectangle" || modelData.key === "ellipse"
+                                        lit: root.config.tool === modelData.key && (!shape || root.config.filled === modelData.filled)
+                                        Accessible.name: shape ? (modelData.filled ? "Filled " : "Outline ") + modelData.key : modelData.label
+                                        contentItem: RowLayout {
+                                            spacing: 5
+                                            Rectangle {
+                                                visible: toolButton.shape
+                                                Layout.preferredWidth: 18
+                                                Layout.preferredHeight: 14
+                                                radius: toolButton.modelData.key === "ellipse" ? 7 : 0
+                                                color: toolButton.modelData.filled ? iconColor : "transparent"
+                                                border.width: 1
+                                                border.color: iconColor
+                                                readonly property color iconColor: !toolButton.enabled ? S.Theme.textMuted : toolButton.lit ? S.Theme.textBright : S.Theme.text
+                                            }
+                                            Text {
+                                                Layout.fillWidth: true
+                                                text: toolButton.text
+                                                font: toolButton.font
+                                                color: !toolButton.enabled ? S.Theme.textMuted : toolButton.lit ? S.Theme.textBright : S.Theme.text
+                                                horizontalAlignment: Text.AlignHCenter
+                                                verticalAlignment: Text.AlignVCenter
+                                                elide: Text.ElideRight
+                                            }
+                                        }
+                                        enabled: !view.drawing
+                                        onClicked: root.setTool(modelData.key, modelData.filled === true)
+                                    }
+                                }
+                            }
+                            Rectangle {
+                                Layout.fillWidth: true
+                                height: 1
+                                color: S.Theme.border
+                            }
+                            RowLayout {
+                                Layout.fillWidth: true
+                                S.SLabel {
+                                    text: "Width"
+                                    Layout.fillWidth: true
+                                }
+                                S.SSpin {
+                                    Layout.preferredWidth: 100
+                                    from: 1
+                                    to: 200
+                                    value: root.config.width
+                                    enabled: !view.drawing
+                                    onValueModified: root.setConfig("width", value)
+                                }
+                                S.SLabel {
+                                    text: "px"
+                                    dim: true
+                                }
+                            }
+                            S.SSlider {
+                                Layout.fillWidth: true
+                                from: 1
+                                to: 200
+                                stepSize: 1
+                                value: root.config.width
+                                enabled: !view.drawing
+                                property bool edited: false
+                                onMoved: {
+                                    if (pressed) {
+                                        edited = true;
+                                        root.previewConfig("width", Math.round(value));
+                                    } else
+                                        root.setConfig("width", Math.round(value));
+                                }
+                                onPressedChanged: if (!pressed && edited) {
+                                    edited = false;
+                                    root.commit("Change paint width", false);
+                                }
+                            }
+                            RowLayout {
+                                Layout.fillWidth: true
+                                S.SLabel {
+                                    text: "Opacity"
+                                    Layout.fillWidth: true
+                                }
+                                S.SSpin {
+                                    Layout.preferredWidth: 100
+                                    from: 0
+                                    to: 100
+                                    value: Math.round(root.config.opacity * 100)
+                                    enabled: !view.drawing
+                                    onValueModified: root.setConfig("opacity", value / 100)
+                                }
+                                S.SLabel {
+                                    text: "%"
+                                    dim: true
+                                }
+                            }
+                            S.SSlider {
+                                Layout.fillWidth: true
+                                from: 0
+                                to: 1
+                                stepSize: 0.01
+                                value: root.config.opacity
+                                enabled: !view.drawing
+                                property bool edited: false
+                                onMoved: {
+                                    if (pressed) {
+                                        edited = true;
+                                        root.previewConfig("opacity", value);
+                                    } else
+                                        root.setConfig("opacity", value);
+                                }
+                                onPressedChanged: if (!pressed && edited) {
+                                    edited = false;
+                                    root.commit("Change paint opacity", false);
+                                }
+                            }
+                            RowLayout {
+                                Layout.fillWidth: true
+                                S.SLabel {
+                                    text: "Feather"
+                                    Layout.fillWidth: true
+                                }
+                                S.SSpin {
+                                    Layout.preferredWidth: 100
+                                    from: 0
+                                    to: 100
+                                    value: Math.round(root.config.feather * 100)
+                                    enabled: root.config.tool === "brush" && !view.drawing
+                                    onValueModified: root.setConfig("feather", value / 100)
+                                }
+                                S.SLabel {
+                                    text: "%"
+                                    dim: true
+                                }
+                            }
+                            S.SSlider {
+                                Layout.fillWidth: true
+                                from: 0
+                                to: 1
+                                stepSize: 0.01
+                                value: root.config.feather
+                                enabled: root.config.tool === "brush" && !view.drawing
+                                property bool edited: false
+                                onMoved: {
+                                    if (pressed) {
+                                        edited = true;
+                                        root.previewConfig("feather", value);
+                                    } else
+                                        root.setConfig("feather", value);
+                                }
+                                onPressedChanged: if (!pressed && edited) {
+                                    edited = false;
+                                    root.commit("Change paint feather", false);
+                                }
+                            }
+                            Rectangle {
+                                Layout.fillWidth: true
+                                height: 1
+                                color: S.Theme.border
+                            }
+                            RowLayout {
+                                Layout.fillWidth: true
+                                spacing: 6
+                                S.SLabel {
+                                    text: "Foreground"
+                                }
+                                S.SButton {
+                                    id: foregroundButton
+                                    Layout.fillWidth: true
+                                    compact: true
+                                    text: root.config.color
+                                    tip: "Choose the foreground color"
+                                    Accessible.name: "Foreground color " + text
+                                    enabled: !view.drawing
+                                    contentItem: RowLayout {
+                                        spacing: 5
+                                        Rectangle {
+                                            Layout.preferredWidth: 22
+                                            Layout.preferredHeight: 20
+                                            color: root.config.color
+                                            border.color: S.Theme.textDim
+                                            radius: 2
+                                        }
+                                        Text {
+                                            Layout.fillWidth: true
+                                            text: foregroundButton.text
+                                            font.pixelSize: S.Theme.fontSm
+                                            font.family: "monospace"
+                                            color: foregroundButton.enabled ? S.Theme.text : S.Theme.textMuted
+                                            verticalAlignment: Text.AlignVCenter
+                                            elide: Text.ElideRight
+                                        }
+                                    }
+                                    onClicked: root.chooseColor(-1)
+                                }
+                            }
+                            GridLayout {
+                                columns: 6
+                                Layout.fillWidth: true
+                                columnSpacing: 5
+                                rowSpacing: 5
+                                Repeater {
+                                    model: {
+                                        root.revision;
+                                        return root.doc.palette;
+                                    }
+                                    S.SButton {
+                                        id: paletteButton
+                                        required property string modelData
+                                        required property int index
+                                        Layout.fillWidth: true
+                                        Layout.minimumWidth: 0
+                                        implicitHeight: 27
+                                        compact: true
+                                        enabled: !view.drawing
+                                        text: modelData
+                                        tip: "Select " + modelData + "; right-click to edit this palette color"
+                                        Accessible.name: "Palette color " + (index + 1) + ": " + modelData
+                                        contentItem: Rectangle {
+                                            implicitWidth: 20
+                                            implicitHeight: 23
+                                            radius: 2
+                                            color: paletteButton.modelData
+                                            border.width: root.config.color === paletteButton.modelData ? 2 : 1
+                                            border.color: root.config.color === paletteButton.modelData ? S.Theme.textBright : S.Theme.border
+                                        }
+                                        onClicked: root.setConfig("color", modelData)
+                                        TapHandler {
+                                            acceptedButtons: Qt.RightButton
+                                            enabled: paletteButton.enabled
+                                            onTapped: root.chooseColor(paletteButton.index)
+                                        }
+                                    }
+                                }
+                            }
+                            Rectangle {
+                                Layout.fillWidth: true
+                                height: 1
+                                color: S.Theme.border
+                            }
+                            S.SLabel {
+                                text: "Background"
+                                font.bold: true
+                                dim: true
+                            }
+                            RowLayout {
+                                Layout.fillWidth: true
+                                S.SButton {
+                                    Layout.fillWidth: true
+                                    text: "Choose…"
+                                    enabled: !view.drawing
+                                    onClicked: root.chooseColor(-2)
+                                }
+                                S.SButton {
+                                    Layout.fillWidth: true
+                                    text: "Transparent"
+                                    enabled: !view.drawing
+                                    lit: {
+                                        root.revision;
+                                        return root.doc.background === "#00000000";
+                                    }
+                                    onClicked: root.setBackground("#00000000")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            S.SLabel {
+                Layout.fillWidth: true
+                visible: root.status.length > 0
+                text: root.status
+                wrapMode: Text.Wrap
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Changes
- Add a retained painter using Qt 6.12 `QtCanvas2D`, including brush, eraser, line, outlined/filled rectangles and ellipses, and rendered-color sampling.
- Use a compact foreground swatch/hex row and a right-click-editable palette serialized with the document.
- Add 0–100% brush feathering with opacity-correct, cached whole-path rendering.
- Use score's command history for edits and Clear; remove custom mark undo/redo, counters, the header, and artboard/fit labels.
- Transfer keyboard focus to the canvas when drawing so Ctrl+Z cannot undo a previously edited numeric field instead of the stroke.

## Dependencies and scope
Stacked on #26 so the shared UI kit is not included in this diff. Companion native PR: https://github.com/ossia/score/pull/2259. Requires Qt 6.12 and native painter support for `Util.openColorDialog`, `Util.imagePixelColor`, and `Script.commitState`.

Only the six `canvas-painter` files are included. No other preset or shared-working-tree changes are included.

## Verification
- Passed `test_unit_js_image`, `test_integration_canvas_painting`, and `test_integration_painter_state` against these exact preset files on Qt 6.12.
- Also passed the existing imported-UI, texture-preview, and GPU-Javascript regressions in the development build.
- Exercised the actual score editor: RGBA palette replacement/save, feathered strokes, all four shape tools, native Undo/Redo, and Clear/Undo.
- The keyboard-focus regression fails before the fix and passes afterward.